### PR TITLE
feat: 多测绘引擎支持 - 新增 6 个搜索引擎

### DIFF
--- a/app/agents/collector.py
+++ b/app/agents/collector.py
@@ -25,10 +25,10 @@ from app.agents import collector_llm, playbook_router, prefilter, scorer, site_c
 from app.agents import target_cluster
 from app.agents.prompts import is_enterprise_src
 from app.db.models import Target, Task
-from app.fofa import client as fofa
+from app.engines import get_engine, EngineResult
 from app.tools.leakcreds import query_leaked_creds
 from app.llm.client import LLMClient, LLMError
-from app.settings_service import llm_client_for_task_optional, resolve_fofa_defaults, resolve_skip_score_threshold
+from app.settings_service import llm_client_for_task_optional, resolve_engine_config, resolve_skip_score_threshold
 
 _EDUSRC_ORG_FILTER = 'org="China Education and Research Network Center"'
 _PREFILTER_CONCURRENCY = int(os.environ.get("COLLECTOR_PREFILTER_CONCURRENCY", "12"))
@@ -234,7 +234,7 @@ async def _resolve_query(task: Task, llm: LLMClient | None) -> tuple[str, str]:
     cfg = dict(task.fofa_config or {})
     history: list[str] = list(cfg.get("history", []))
     raw = (task.fofa_query or "").strip()
-    intent_mode = cfg.get("intent_mode") or resolve_fofa_defaults(task).get("intent_mode", "")
+    intent_mode = cfg.get("intent_mode") or resolve_engine_config(task).get("intent_mode", "")
     # 'syntax' / 'intent'，未设则启发式判断
 
     # 启发式：含 FOFA 字段符号视为语法，否则视为自然语言意图
@@ -401,12 +401,18 @@ async def _fofa_collect(
             await progress(phase, text, **payload)
 
     cfg = dict(task.fofa_config or {})
-    defaults = resolve_fofa_defaults(task)
+    defaults = resolve_engine_config(task)
+    engine_name = defaults["engine"]
+    engine = get_engine(engine_name)
+    if engine is None:
+        return 0
+
     key = defaults["key"]
     if not key:
         return 0
     max_pages = int(defaults["max_pages"])
     size = int(defaults["page_size"])
+    base_url = defaults.get("base_url") or engine.get_default_base_url()
 
     llm = _llm_for_task(task)
     history: list[str] = list(cfg.get("history", []))
@@ -425,37 +431,36 @@ async def _fofa_collect(
 
     next_cursor = cursor + 1
     try:
-        res = await fofa.search(key, cur_query, page=next_cursor, size=size,
-                                base_url=defaults.get("base_url"))
-    except fofa.FofaError as e:
-        # FOFA 失败不阻断主循环，但必须：
-        # 1) 游标不前进——否则一次瞬时错误就把当前页永久跳过（漏搜）。
-        # 2) 显式上报到看板——否则只会刷一堆「候选0/存活0/过滤器0/0」，
-        #    看板上完全看不出是 FOFA 挂了，极难排查（本次踩坑点）。
+        res = await engine.search(key, cur_query, page=next_cursor, page_size=size,
+                                  base_url=base_url)
+    except (ValueError, Exception) as e:
         err = f"{e}"[:300]
         cfg["last_fofa_error"] = err
         cfg["collector_phase"] = "fofa_error"
-        # 账号级致命错误（key 无效/过期/无 F 点/权限）连续累计，达阈值由上层暂停任务；
-        # 瞬时错误（网络/超时）重置计数，避免偶发抖动误触发暂停。
-        if getattr(e, "account_error", False):
+        # 账号级致命错误标记（各引擎用不同的错误判断逻辑）
+        err_lower = str(e).lower()
+        is_account_err = any(m in err_lower for m in (
+            "key", "token", "无效", "过期", "余额", "quota", "permission",
+            "unauthorized", "forbidden", "account", "401", "403",
+        ))
+        if is_account_err:
             cfg["fofa_auth_fail_count"] = int(cfg.get("fofa_auth_fail_count", 0)) + 1
             await report(
                 "fofa_error",
-                f"FOFA 账号无效（第 {cfg['fofa_auth_fail_count']} 次）：{err}",
+                f"{engine.display_name} 账号无效（第 {cfg['fofa_auth_fail_count']} 次）：{err}",
                 fofa_error=err, cursor=cursor, fofa_auth_fail=cfg["fofa_auth_fail_count"],
             )
         else:
             cfg["fofa_auth_fail_count"] = 0
             await report(
                 "fofa_error",
-                f"FOFA 检索失败，已跳过本轮（游标停留第 {cursor} 页，下轮重试）：{err}",
+                f"{engine.display_name} 检索失败，已跳过本轮（游标停留第 {cursor} 页，下轮重试）：{err}",
                 fofa_error=err, cursor=cursor,
             )
         task.fofa_config = {**cfg}
         return 0
     cursor = next_cursor
     cfg["fofa_auth_fail_count"] = 0
-    # 成功即清掉旧的错误标记，避免看板长期挂着一条早已恢复的 FOFA 报错。
     cfg.pop("last_fofa_error", None)
 
     # host 归属兜底过滤：即使 FOFA 语法因运算符优先级或 LLM 演化丢锚点而放宽范围，
@@ -471,10 +476,10 @@ async def _fofa_collect(
         anchor_domains = _extract_scope_anchors((task.fofa_query or "")).get("domains") or []
         scope_domains = set(anchor_domains)
 
-    fields = res["fields"]
+    fields = res.fields
     candidates: list[dict] = []
     dropped_oos = 0
-    for row in res["results"]:
+    for row in res.results:
         rec = dict(zip(fields, row)) if isinstance(row, list) else row
         host = normalize_host(rec.get("host") or rec.get("domain") or rec.get("ip") or "")
         if not host or host in seen:

--- a/app/api/dto.py
+++ b/app/api/dto.py
@@ -8,17 +8,23 @@ from pydantic import BaseModel, Field
 
 class ModelConfigDTO(BaseModel):
     base_url: str = "https://api.deepseek.com/v1"
-    api_key: str = ""           # 留空则用服务端 .env 默认
+    api_key: str = ""
     model: str = "deepseek-chat"
-    prompt_version: str = ""     # current / legacy / modern；留空则用全局默认
+    prompt_version: str = ""
 
 
 class FofaConfigDTO(BaseModel):
-    key: str = ""               # 留空则用服务端 .env 默认
-    base_url: str = ""          # 自定义 FOFA API 端点；留空则用服务端 .env 默认(官方 https://fofa.info)
+    key: str = ""
+    base_url: str = ""
     max_pages: int = 20
     page_size: int = 100
-    intent_mode: str = ""       # syntax=用户给的是FOFA语法 / intent=自然语言意图(LLM翻译) / 空=自动判断
+    intent_mode: str = ""
+
+
+class EngineConfigDTO(BaseModel):
+    """多引擎配置。"""
+    key: str = ""
+    base_url: str = ""
 
 
 class CreateTaskRequest(BaseModel):
@@ -26,11 +32,13 @@ class CreateTaskRequest(BaseModel):
     src_type: str = "edusrc"
     vuln_types: list[str] = Field(default_factory=list)
     src_rules: str = ""
-    target_source: str = "fofa"        # fofa / manual / both / site
+    target_source: str = "fofa"
+    engine: str = ""                                           # 搜索引擎：fofa/quake/hunter/...
     fofa_query: str = ""
     manual_targets: list[str] = Field(default_factory=list)
     model_config_data: ModelConfigDTO = Field(default_factory=ModelConfigDTO)
     fofa_config: FofaConfigDTO = Field(default_factory=FofaConfigDTO)
+    engine_config: EngineConfigDTO = Field(default_factory=EngineConfigDTO)  # 引擎 Key/URL
     concurrency: int = 3
 
 
@@ -49,16 +57,23 @@ class PartialFofaConfigDTO(BaseModel):
     intent_mode: Optional[str] = None
 
 
+class PartialEngineConfigDTO(BaseModel):
+    key: Optional[str] = None
+    base_url: Optional[str] = None
+
+
 class UpdateTaskRequest(BaseModel):
     name: Optional[str] = None
     src_type: Optional[str] = None
     vuln_types: Optional[list[str]] = None
     src_rules: Optional[str] = None
     target_source: Optional[str] = None
+    engine: Optional[str] = None                                 # 切换引擎
     fofa_query: Optional[str] = None
     manual_targets: Optional[list[str]] = None
     model_config_data: Optional[PartialModelConfigDTO] = None
     fofa_config: Optional[PartialFofaConfigDTO] = None
+    engine_config: Optional[PartialEngineConfigDTO] = None
     concurrency: Optional[int] = None
 
 
@@ -66,19 +81,18 @@ class TaskStats(BaseModel):
     queued: int = 0
     scanning: int = 0
     done: int = 0
-    dead: int = 0          # 硬骨头库：重试/超时/异常仍无果
-    skipped: int = 0       # 低分垃圾资产直接跳过
+    dead: int = 0
+    skipped: int = 0
     findings_total: int = 0
     pending_review: int = 0
     accepted: int = 0
     ignored: int = 0
-    deepen: int = 0        # 被审核打回深挖的线索数
-    killsweep: int = 0     # 通杀列命中数（人工复审通过后触发通杀 Hunter）
-    # 各 Tab 的权威计数（用户复审维度），供前端徽标/指标卡直接用，不再依赖懒加载数组
-    review_pending: int = 0   # 复审队列：AI accepted 且用户 pending
-    submit_ready: int = 0     # 待提交：用户复审 passed 且尚未提交
-    rejected: int = 0         # 已驳回：用户复审 rejected
-    archived: int = 0         # AI 未采纳：verdict ignored/deepen 且用户 pending、非 superseded
+    deepen: int = 0
+    killsweep: int = 0
+    review_pending: int = 0
+    submit_ready: int = 0
+    rejected: int = 0
+    archived: int = 0
 
 
 class TaskResponse(BaseModel):
@@ -88,17 +102,18 @@ class TaskResponse(BaseModel):
     src_type: str
     vuln_types: list[str]
     target_source: str
+    engine: str = ""
     fofa_query: str
     concurrency: int
     src_rules: str = ""
     manual_targets: list[str] = Field(default_factory=list)
     model_config_data: dict = Field(default_factory=dict)
     fofa_config: dict = Field(default_factory=dict)
+    engine_config: dict = Field(default_factory=dict)
     llm_usage: dict = Field(default_factory=dict)
     created_at: str
     updated_at: str
     stats: Optional[TaskStats] = None
-    # 待人工复审数（AI accepted 且用户未处理）——任务卡片红点用，列表接口轻量填充
     pending_user_review: int = 0
 
 
@@ -117,13 +132,21 @@ class FofaSettingsDTO(BaseModel):
     default_intent_mode: Optional[str] = None
 
 
+class EngineSettingsDTO(BaseModel):
+    """单个搜索引擎的设置。"""
+    key: Optional[str] = None
+    base_url: Optional[str] = None
+
+
 class DefaultsSettingsDTO(BaseModel):
     concurrency: Optional[int] = None
     skip_score_threshold: Optional[float] = None
     worker_prompt_version: Optional[str] = None
+    engine: Optional[str] = None
 
 
 class SettingsUpdateRequest(BaseModel):
     llm: Optional[LLMSettingsDTO] = None
     fofa: Optional[FofaSettingsDTO] = None
+    engines: Optional[dict[str, EngineSettingsDTO]] = None   # 按引擎名索引
     defaults: Optional[DefaultsSettingsDTO] = None

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -15,7 +15,7 @@ from app.db.session import get_session
 from app.llm.usage import usage_snapshot
 from app.orchestrator import manager
 from app.security import resolve_role, token_from_headers
-from app.settings_service import resolve_fofa_defaults, resolve_llm_config, resolve_worker_prompt_version
+from app.settings_service import resolve_engine_config, resolve_llm_config, resolve_worker_prompt_version
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
@@ -141,8 +141,9 @@ def _public_model_config(task: Task) -> dict:
 
 def _public_fofa_config(task: Task) -> dict:
     cfg = dict(task.fofa_config or {})
-    eff = resolve_fofa_defaults(task)
+    eff = resolve_engine_config(task)
     return {
+        "engine": eff.get("engine", "fofa"),
         "base_url": eff["base_url"],
         "max_pages": eff["max_pages"],
         "page_size": eff["page_size"],
@@ -166,11 +167,12 @@ def _task_to_dto(t: Task, stats: TaskStats | None = None,
     return TaskResponse(
         id=t.id, name=_observer_task_name(t.name, t.id) if observer else t.name, status=t.status, src_type=t.src_type,
         vuln_types=t.vuln_types or [], target_source=t.target_source,
-        fofa_query="" if observer else t.fofa_query, concurrency=t.concurrency,
+        engine=t.engine or "", fofa_query="" if observer else t.fofa_query, concurrency=t.concurrency,
         src_rules="" if observer else (t.src_rules or ""),
         manual_targets=[] if observer else (t.manual_targets or []),
         model_config_data=model_config,
         fofa_config=_observer_fofa_config() if observer else _public_fofa_config(t),
+        engine_config={} if observer else {"engine": t.engine or ""},
         llm_usage={} if observer else usage_snapshot(t.id, model_config.get("model", "")),
         created_at=t.created_at.isoformat(), updated_at=t.updated_at.isoformat(),
         stats=stats, pending_user_review=pending_user_review,
@@ -247,12 +249,20 @@ async def _compute_stats(session: AsyncSession, task_id: str) -> TaskStats:
 async def create_task(req: CreateTaskRequest, session: AsyncSession = Depends(get_session)):
     if req.target_source not in {"fofa", "manual", "both", "site"}:
         raise HTTPException(400, "target_source 必须是 fofa/manual/both/site")
+    engine_name = req.engine or ""
+    # 引擎配置：合并 engine_config 和向后兼容的 fofa_config
+    fofa_cfg = req.fofa_config.model_dump(exclude_defaults=True) if req.fofa_config else {}
+    eng_cfg = req.engine_config.model_dump(exclude_defaults=True) if req.engine_config else {}
+    if engine_name and engine_name != "fofa" and eng_cfg.get("key"):
+        fofa_cfg["key"] = eng_cfg["key"]
+    if eng_cfg.get("base_url"):
+        fofa_cfg["base_url"] = eng_cfg["base_url"]
     task = Task(
         name=req.name, src_type=normalize_src_type(req.src_type), vuln_types=req.vuln_types,
         src_rules=req.src_rules, target_source=req.target_source,
-        fofa_query=req.fofa_query, manual_targets=req.manual_targets,
+        engine=engine_name, fofa_query=req.fofa_query, manual_targets=req.manual_targets,
         model_config_json=req.model_config_data.model_dump(exclude_defaults=True),
-        fofa_config=req.fofa_config.model_dump(exclude_defaults=True), concurrency=req.concurrency,
+        fofa_config=fofa_cfg, concurrency=req.concurrency,
         status="created",
     )
     session.add(task)
@@ -384,6 +394,8 @@ async def update_task(task_id: str, req: UpdateTaskRequest, session: AsyncSessio
         if req.target_source not in {"fofa", "manual", "both", "site"}:
             raise HTTPException(400, "target_source 必须是 fofa/manual/both/site")
         task.target_source = req.target_source
+    if req.engine is not None:
+        task.engine = req.engine
     if req.manual_targets is not None:
         task.manual_targets = [t.strip() for t in req.manual_targets if str(t).strip()]
     if req.concurrency is not None:
@@ -402,6 +414,15 @@ async def update_task(task_id: str, req: UpdateTaskRequest, session: AsyncSessio
         if str(patch.get("api_key") or "").strip():
             cfg["api_key"] = str(patch["api_key"]).strip()
         task.model_config_json = cfg
+
+    if req.engine_config is not None:
+        ec_patch = req.engine_config.model_dump(exclude_unset=True)
+        ec_cfg = dict(task.fofa_config or {})
+        if "key" in ec_patch and str(ec_patch.get("key") or "").strip():
+            ec_cfg["key"] = str(ec_patch["key"]).strip()
+        if "base_url" in ec_patch and ec_patch["base_url"] is not None:
+            ec_cfg["base_url"] = ec_patch["base_url"]
+        task.fofa_config = ec_cfg
 
     if req.fofa_config is not None:
         patch = req.fofa_config.model_dump(exclude_unset=True)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -39,6 +39,7 @@ class Task(Base):
     manual_targets: Mapped[list] = mapped_column(JSON, default=list)
     model_config_json: Mapped[dict] = mapped_column("model_config", JSON, default=dict)
     fofa_config: Mapped[dict] = mapped_column(JSON, default=dict)       # keys/max_pages/page_size/cursor
+    engine: Mapped[str] = mapped_column(String(20), default="")         # 搜索引擎：fofa/quake/hunter/zoomeye/shodan/censys
     concurrency: Mapped[int] = mapped_column(Integer, default=3)
     # created / running / paused / stopped / idle
     status: Mapped[str] = mapped_column(String(20), default="created")
@@ -257,5 +258,6 @@ class SystemSettings(Base):
     id: Mapped[str] = mapped_column(String(32), primary_key=True, default="global")
     llm: Mapped[dict] = mapped_column(JSON, default=dict)       # base_url/api_key/model/temperature
     fofa: Mapped[dict] = mapped_column(JSON, default=dict)      # key/max_pages/page_size/default_intent_mode
-    defaults: Mapped[dict] = mapped_column(JSON, default=dict)  # concurrency/skip_score_threshold 等
+    engines: Mapped[dict] = mapped_column(JSON, default=dict)   # {engine_name: {key, base_url, ...}}
+    defaults: Mapped[dict] = mapped_column(JSON, default=dict)  # concurrency/skip_score_threshold/engine
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=_now, onupdate=_now)

--- a/app/engines/__init__.py
+++ b/app/engines/__init__.py
@@ -1,0 +1,16 @@
+"""多测绘引擎统一接口。"""
+
+from app.engines.base import EngineResult, SearchEngine, get_default_engine, get_engine, list_engines, register_engine
+
+# 导入所有引擎以触发注册
+import app.engines.fofa  # noqa: F401
+import app.engines.quake  # noqa: F401
+import app.engines.hunter  # noqa: F401
+import app.engines.zoomeye  # noqa: F401
+import app.engines.shodan  # noqa: F401
+import app.engines.censys  # noqa: F401
+
+__all__ = [
+    "EngineResult", "SearchEngine",
+    "get_engine", "list_engines", "get_default_engine", "register_engine",
+]

--- a/app/engines/base.py
+++ b/app/engines/base.py
@@ -1,0 +1,90 @@
+"""引擎抽象基类 — 所有测绘搜索引擎统一接口。"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class EngineResult:
+    """统一返回格式，collector 层依赖此结构。"""
+    fields: list[str] = field(default_factory=lambda: ["host", "ip", "port", "title", "domain", "org"])
+    results: list[list[Any]] = field(default_factory=list)
+    size: int = 0
+    page: int = 1
+    engine: str = ""
+
+
+class SearchEngine(ABC):
+    """搜索引擎基类。"""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """引擎标识符，如 'fofa', 'quake', 'hunter'。"""
+        ...
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """引擎展示名，如 'FOFA', '360 Quake'。"""
+        ...
+
+    @property
+    @abstractmethod
+    def env_key_name(self) -> str:
+        """环境变量名后缀，如 'FOFA_KEY' 中的 FOFA。"""
+        ...
+
+    @abstractmethod
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        """执行搜索，返回统一格式的 EngineResult。"""
+        ...
+
+    def translate_query(self, query: str, target_engine: str) -> str:
+        """将本引擎的查询语法翻译为目标引擎语法（默认返回原样）。"""
+        return query
+
+    def get_default_base_url(self) -> str:
+        """默认 API 端点。"""
+        return ""
+
+
+# ─── 引擎注册表 ───────────────────────────────────────────────
+_engines: dict[str, type[SearchEngine]] = {}
+
+
+def register_engine(engine_cls: type[SearchEngine]) -> type[SearchEngine]:
+    """注册引擎类到全局注册表。"""
+    inst = engine_cls()
+    _engines[inst.name] = engine_cls
+    return engine_cls
+
+
+def get_engine(name: str) -> SearchEngine | None:
+    """按名称获取引擎实例。"""
+    cls = _engines.get(name)
+    if cls is None:
+        return None
+    return cls()
+
+
+def list_engines() -> list[dict[str, str]]:
+    """列出所有已注册引擎的信息。"""
+    return [
+        {"name": cls().name, "display_name": cls().display_name}
+        for cls in _engines.values()
+    ]
+
+
+def get_default_engine() -> str:
+    """默认引擎。"""
+    return "fofa"

--- a/app/engines/censys.py
+++ b/app/engines/censys.py
@@ -1,0 +1,91 @@
+"""Censys 搜索引擎适配。"""
+from __future__ import annotations
+
+import base64
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+@register_engine
+class CensysEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "censys"
+
+    @property
+    def display_name(self) -> str:
+        return "Censys"
+
+    @property
+    def env_key_name(self) -> str:
+        return "CENSYS"
+
+    def get_default_base_url(self) -> str:
+        return "https://search.censys.io"
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise ValueError("缺少 Censys API Key")
+        # Censys 的 api_key 格式为 "API_ID:SECRET"
+        if ":" not in api_key:
+            raise ValueError("Censys API Key 格式应为 API_ID:SECRET")
+        base = (base_url or self.get_default_base_url()).rstrip("/")
+        basic_auth = base64.b64encode(api_key.encode()).decode()
+        headers = {"Authorization": f"Basic {basic_auth}"}
+        params = {"q": query, "per_page": str(page_size), "page": str(page)}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(f"{base}/api/v2/hosts/search", params=params, headers=headers)
+                data = resp.json()
+        except Exception as e:
+            raise ValueError(f"Censys 请求失败: {e}") from e
+
+        hits = data.get("result", {}).get("hits", [])
+        results = []
+        for item in hits:
+            ip = item.get("ip", "")
+            services = item.get("services", [])
+            # 取第一个 HTTP 服务的 title
+            title = ""
+            hostname = ""
+            org = ""
+            port = ""
+            for svc in services:
+                if isinstance(svc, dict):
+                    if not port:
+                        port = str(svc.get("port", ""))
+                    http = svc.get("http", {}) if isinstance(svc.get("http"), dict) else {}
+                    if http and http.get("title"):
+                        title = http.get("title", "")
+                    if svc.get("service_name") == "HTTP" and http:
+                        hostname = http.get("host", hostname)
+                else:
+                    if not port:
+                        port = str(svc)
+            location = item.get("location", {}) or {}
+            org = location.get("country", "") if isinstance(location, dict) else ""
+            results.append([
+                hostname or ip,
+                ip,
+                port,
+                title,
+                hostname,
+                org,
+            ])
+
+        return EngineResult(
+            fields=["host", "ip", "port", "title", "domain", "org"],
+            results=results,
+            size=data.get("result", {}).get("total", 0),
+            page=page,
+            engine="censys",
+        )

--- a/app/engines/fofa.py
+++ b/app/engines/fofa.py
@@ -1,0 +1,109 @@
+"""FOFA 搜索引擎适配。"""
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+BASE = "https://fofa.info"
+
+# 允许指向内网/私有的 FOFA base_url 白名单
+_FOFA_ALLOWED_HOSTS = {
+    h.strip().lower()
+    for h in os.environ.get("FOFA_ALLOWED_HOSTS", "").split(",")
+    if h.strip()
+}
+
+
+class FofaError(Exception):
+    def __init__(self, message: str, account_error: bool = False):
+        super().__init__(message)
+        self.account_error = account_error
+
+
+_FOFA_ACCOUNT_ERROR_MARKERS = (
+    "820000", "820001", "-700", "账号无效", "账号已过期", "账号过期",
+    "无效的fofa", "无效的 fofa", "f点不足", "f币不足", "余额不足", "配额",
+    "权限不足", "没有权限", "会员", "account invalid", "invalid key",
+    "expired", "insufficient", "quota", "permission", "unauthorized", "forbidden",
+)
+
+
+def _is_account_error(errmsg: str) -> bool:
+    text = str(errmsg or "").lower()
+    return any(m in text for m in _FOFA_ACCOUNT_ERROR_MARKERS)
+
+
+def _qbase64(query: str) -> str:
+    return base64.b64encode(query.encode("utf-8")).decode("ascii")
+
+
+@register_engine
+class FofaEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "fofa"
+
+    @property
+    def display_name(self) -> str:
+        return "FOFA"
+
+    @property
+    def env_key_name(self) -> str:
+        return "FOFA"
+
+    def get_default_base_url(self) -> str:
+        return BASE
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise FofaError("缺少 FOFA key")
+        base = (base_url or BASE).rstrip("/")
+        # SSRF 防护
+        from app.tools.netguard import SsrfBlocked, assert_safe_outbound_url
+        try:
+            assert_safe_outbound_url(
+                f"{base}/api/v1/search/all", allow_extra_hosts=_FOFA_ALLOWED_HOSTS
+            )
+        except SsrfBlocked as e:
+            raise FofaError(f"FOFA base_url 不被允许：{e}") from e
+
+        fields = "host,ip,port,title,domain,org"
+        params = {
+            "key": api_key, "qbase64": _qbase64(query),
+            "fields": fields, "page": str(page), "size": str(page_size), "full": "false",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(f"{base}/api/v1/search/all", params=params)
+                try:
+                    data = resp.json()
+                except Exception:
+                    raise FofaError(f"FOFA 返回非 JSON (HTTP {resp.status_code}): {resp.text[:200]}")
+        except FofaError:
+            raise
+        except httpx.HTTPError as e:
+            raise FofaError(f"FOFA 请求失败: {type(e).__name__}: {e}") from e
+
+        if data.get("error"):
+            errmsg = data.get("errmsg")
+            raise FofaError(f"FOFA 错误: {errmsg}", account_error=_is_account_error(errmsg))
+
+        return EngineResult(
+            fields=fields.split(","),
+            results=data.get("results", []),
+            size=data.get("size", 0),
+            page=page,
+            engine="fofa",
+        )

--- a/app/engines/hunter.py
+++ b/app/engines/hunter.py
@@ -1,0 +1,77 @@
+"""Hunter (鹰图) 搜索引擎适配。"""
+from __future__ import annotations
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+@register_engine
+class HunterEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "hunter"
+
+    @property
+    def display_name(self) -> str:
+        return "Hunter (鹰图)"
+
+    @property
+    def env_key_name(self) -> str:
+        return "HUNTER"
+
+    def get_default_base_url(self) -> str:
+        return "https://hunter.qianxin.com"
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise ValueError("缺少 Hunter API Key")
+        base = (base_url or self.get_default_base_url()).rstrip("/")
+        params = {
+            "api-key": api_key,
+            "search": query,
+            "page": str(page),
+            "page_size": str(page_size),
+            "is_web": "1",
+            "status_code": "200",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(f"{base}/api/v1/search", params=params)
+                data = resp.json()
+        except Exception as e:
+            raise ValueError(f"Hunter 请求失败: {e}") from e
+
+        # 猎鹰返回 code=200 表示成功
+        if data.get("code") != 200:
+            msg = data.get("message", str(data.get("data", "")))
+            raise ValueError(f"Hunter 错误: {msg}")
+
+        items = data.get("data", {}).get("arr", [])
+        results = []
+        for item in items:
+            url = item.get("url", "")
+            host = item.get("domain") or item.get("ip", "")
+            results.append([
+                host,
+                item.get("ip", ""),
+                str(item.get("port", "")),
+                item.get("title", ""),
+                item.get("domain", ""),
+                item.get("company_name", ""),
+            ])
+
+        return EngineResult(
+            fields=["host", "ip", "port", "title", "domain", "org"],
+            results=results,
+            size=data.get("data", {}).get("total", 0),
+            page=page,
+            engine="hunter",
+        )

--- a/app/engines/quake.py
+++ b/app/engines/quake.py
@@ -1,0 +1,71 @@
+"""360 Quake 搜索引擎适配。"""
+from __future__ import annotations
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+@register_engine
+class QuakeEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "quake"
+
+    @property
+    def display_name(self) -> str:
+        return "360 Quake"
+
+    @property
+    def env_key_name(self) -> str:
+        return "QUAKE"
+
+    def get_default_base_url(self) -> str:
+        return "https://quake.360.net"
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise ValueError("缺少 Quake API Key")
+        base = (base_url or self.get_default_base_url()).rstrip("/")
+        url = f"{base}/api/v3/search/quake_service"
+        headers = {"X-QuakeToken": api_key, "Content-Type": "application/json"}
+        payload = {"query": query, "start": (page - 1) * page_size, "size": page_size}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(url, json=payload, headers=headers)
+                data = resp.json()
+        except Exception as e:
+            raise ValueError(f"Quake 请求失败: {e}") from e
+
+        if data.get("code") != 0:
+            msg = data.get("message", str(data.get("data", "")))
+            raise ValueError(f"Quake 错误: {msg}")
+
+        items = data.get("data", {}).get("items", [])
+        results = []
+        for item in items:
+            host = item.get("hostname") or item.get("ip", "")
+            port = str(item.get("port", ""))
+            results.append([
+                host,
+                item.get("ip", ""),
+                port,
+                item.get("service", {}).get("title", "") if isinstance(item.get("service"), dict) else "",
+                host,
+                item.get("org", ""),
+            ])
+
+        return EngineResult(
+            fields=["host", "ip", "port", "title", "domain", "org"],
+            results=results,
+            size=data.get("data", {}).get("total", 0),
+            page=page,
+            engine="quake",
+        )

--- a/app/engines/shodan.py
+++ b/app/engines/shodan.py
@@ -1,0 +1,72 @@
+"""Shodan 搜索引擎适配。"""
+from __future__ import annotations
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+@register_engine
+class ShodanEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "shodan"
+
+    @property
+    def display_name(self) -> str:
+        return "Shodan"
+
+    @property
+    def env_key_name(self) -> str:
+        return "SHODAN"
+
+    def get_default_base_url(self) -> str:
+        return "https://api.shodan.io"
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise ValueError("缺少 Shodan API Key")
+        base = (base_url or self.get_default_base_url()).rstrip("/")
+        params = {"key": api_key, "query": query, "page": str(page), "limit": str(min(page_size, 100))}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(f"{base}/shodan/host/search", params=params)
+                data = resp.json()
+        except Exception as e:
+            raise ValueError(f"Shodan 请求失败: {e}") from e
+
+        if "error" in data:
+            raise ValueError(f"Shodan 错误: {data['error']}")
+
+        matches = data.get("matches", [])
+        results = []
+        for item in matches:
+            http_data = item.get("http", {}) if isinstance(item.get("http"), dict) else {}
+            title = ""
+            if http_data:
+                title = http_data.get("title", "")
+            hostnames = item.get("hostnames", [])
+            host = hostnames[0] if hostnames else item.get("ip_str", "")
+            results.append([
+                host,
+                item.get("ip_str", ""),
+                str(item.get("port", "")),
+                title,
+                host,
+                item.get("org", ""),
+            ])
+
+        return EngineResult(
+            fields=["host", "ip", "port", "title", "domain", "org"],
+            results=results,
+            size=data.get("total", 0),
+            page=page,
+            engine="shodan",
+        )

--- a/app/engines/zoomeye.py
+++ b/app/engines/zoomeye.py
@@ -1,0 +1,67 @@
+"""ZoomEye 搜索引擎适配。"""
+from __future__ import annotations
+
+import httpx
+
+from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+@register_engine
+class ZoomEyeEngine(SearchEngine):
+    @property
+    def name(self) -> str:
+        return "zoomeye"
+
+    @property
+    def display_name(self) -> str:
+        return "ZoomEye"
+
+    @property
+    def env_key_name(self) -> str:
+        return "ZOOMEYE"
+
+    def get_default_base_url(self) -> str:
+        return "https://api.zoomeye.org"
+
+    async def search(
+        self,
+        api_key: str,
+        query: str,
+        page: int = 1,
+        page_size: int = 100,
+        base_url: str | None = None,
+    ) -> EngineResult:
+        if not api_key:
+            raise ValueError("缺少 ZoomEye API Key")
+        base = (base_url or self.get_default_base_url()).rstrip("/")
+
+        # ZoomEye 同时支持 web / host 搜索，优先 web（侧重 Web 应用）
+        params = {"query": query, "page": str(page), "size": str(page_size)}
+        headers = {"API-KEY": api_key}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(f"{base}/web/search", params=params, headers=headers)
+                data = resp.json()
+        except Exception as e:
+            raise ValueError(f"ZoomEye 请求失败: {e}") from e
+
+        matches = data.get("matches", [])
+        results = []
+        for item in matches:
+            site_info = item.get("site", {}) if isinstance(item.get("site"), dict) else {}
+            results.append([
+                site_info.get("host", item.get("ip", "")),
+                item.get("ip", ""),
+                str(item.get("port", "")),
+                item.get("title", ""),
+                site_info.get("domain", item.get("domain", "")),
+                item.get("geoinfo", {}).get("org", "") if isinstance(item.get("geoinfo"), dict) else "",
+            ])
+
+        return EngineResult(
+            fields=["host", "ip", "port", "title", "domain", "org"],
+            results=results,
+            size=data.get("total", 0),
+            page=page,
+            engine="zoomeye",
+        )

--- a/app/settings_service.py
+++ b/app/settings_service.py
@@ -11,10 +11,11 @@ from app.config import LLMConfig, llm_config
 from app.agents.prompts import normalize_worker_prompt_version
 from app.db.models import SystemSettings, Task
 from app.db.session import SessionLocal
+from app.engines import get_engine, list_engines, get_default_engine
 
 SETTINGS_ID = "global"
 
-_cache: dict[str, Any] = {"llm": {}, "fofa": {}, "defaults": {}}
+_cache: dict[str, Any] = {"llm": {}, "fofa": {}, "engines": {}, "defaults": {}}
 
 
 # 统一脱敏占位：不再泄露密钥首尾字符，避免降低离线爆破成本。
@@ -29,7 +30,7 @@ def mask_secret(value: str) -> str:
 
 
 def is_masked_secret(value: str) -> bool:
-    """判断传入值是否为前端回显的脱敏占位（应视为“未修改”，不可回写覆盖真实密钥）。"""
+    """判断传入值是否为前端回显的脱敏占位（应视为"未修改"，不可回写覆盖真实密钥）。"""
     v = str(value or "").strip()
     if not v:
         return False
@@ -55,11 +56,37 @@ def _env_fofa() -> dict[str, Any]:
     }
 
 
+def _env_engines() -> dict[str, Any]:
+    """从环境变量读取所有已注册引擎的 API Key 和 base_url。
+    约定环境变量名为 {ENGINE_ENV_KEY}_KEY 和 {ENGINE_ENV_KEY}_BASE_URL。
+    """
+    result: dict[str, dict[str, str]] = {}
+    for eng in list_engines():
+        name = eng["name"]
+        env_key = name.upper()
+        key = os.environ.get(f"{env_key}_KEY", "")
+        base_url = os.environ.get(f"{env_key}_BASE_URL", "")
+        if key:
+            result.setdefault(name, {})["key"] = key
+        if base_url:
+            result.setdefault(name, {})["base_url"] = base_url
+    # 兼容旧 FOFA_KEY / FOFA_BASE_URL
+    if "fofa" not in result:
+        fofa_key = os.environ.get("FOFA_KEY", "")
+        fofa_base = os.environ.get("FOFA_BASE_URL", "")
+        if fofa_key:
+            result["fofa"] = {"key": fofa_key}
+            if fofa_base:
+                result["fofa"]["base_url"] = fofa_base
+    return result
+
+
 def _env_defaults() -> dict[str, Any]:
     return {
         "concurrency": 3,
         "skip_score_threshold": float(os.environ.get("SKIP_SCORE_THRESHOLD", "-10")),
         "worker_prompt_version": normalize_worker_prompt_version(os.environ.get("WORKER_PROMPT_VERSION", "legacy")),
+        "engine": os.environ.get("SEARCH_ENGINE", get_default_engine()),
     }
 
 
@@ -76,6 +103,7 @@ def effective_settings() -> dict[str, Any]:
     return {
         "llm": _merge_section(_cache.get("llm"), _env_llm()),
         "fofa": _merge_section(_cache.get("fofa"), _env_fofa()),
+        "engines": _merge_section(_cache.get("engines"), _env_engines()),
         "defaults": _merge_section(_cache.get("defaults"), _env_defaults()),
     }
 
@@ -91,29 +119,77 @@ def resolve_llm_config(task: Task | None = None) -> LLMConfig:
     )
 
 
-def resolve_fofa_key(task: Task | None = None) -> str:
-    eff = effective_settings()["fofa"]
+# ── 引擎相关解析函数 ──────────────────────────────────────────
+
+def resolve_engine_name(task: Task | None = None) -> str:
+    """获取任务使用的搜索引擎名称。"""
+    if task and task.engine:
+        return task.engine
+    eff = effective_settings()["defaults"]
+    return str(eff.get("engine") or get_default_engine())
+
+
+def resolve_engine_key(engine_name: str, task: Task | None = None) -> str:
+    """获取指定引擎的 API Key（任务级 > DB缓存 > 环境变量）。"""
+    eff = effective_settings()["engines"]
+    # 任务级 fofa_config 兼容旧版
+    if engine_name == "fofa" and task:
+        cfg = task.fofa_config or {}
+        if cfg.get("key"):
+            return str(cfg["key"])
+    eng_cfg = eff.get(engine_name, {})
+    return str(eng_cfg.get("key") or "")
+
+
+def resolve_engine_base_url(engine_name: str, task: Task | None = None) -> str:
+    """获取指定引擎的 base_url。"""
+    engine = get_engine(engine_name)
+    default = engine.get_default_base_url() if engine else ""
+    eff = effective_settings()["engines"]
+    # 任务级 fofa_config 兼容旧版
+    if engine_name == "fofa" and task:
+        cfg = task.fofa_config or {}
+        if cfg.get("base_url"):
+            return str(cfg["base_url"])
+    eng_cfg = eff.get(engine_name, {})
+    return str(eng_cfg.get("base_url") or default)
+
+
+def resolve_engine_config(task: Task | None = None) -> dict[str, Any]:
+    """解析任务使用的引擎完整配置。"""
+    engine_name = resolve_engine_name(task)
+    # 兼容旧版 fofa_config 分页设置
     cfg = (task.fofa_config or {}) if task else {}
-    return str(cfg.get("key") or eff.get("key") or "")
+    eff = effective_settings()["engines"]
+    eng_cfg = eff.get(engine_name, {})
+    return {
+        "engine": engine_name,
+        "key": resolve_engine_key(engine_name, task),
+        "base_url": resolve_engine_base_url(engine_name, task),
+        "max_pages": int(cfg.get("max_pages") or eng_cfg.get("max_pages") or 20),
+        "page_size": int(cfg.get("page_size") or eng_cfg.get("page_size") or 100),
+        "intent_mode": str(cfg.get("intent_mode") or ""),
+    }
+
+
+# ── 旧版兼容 ──────────────────────────────────────────────────
+
+def resolve_fofa_key(task: Task | None = None) -> str:
+    """兼容旧版：等价于 resolve_engine_key('fofa', task)。"""
+    return resolve_engine_key("fofa", task)
 
 
 def resolve_fofa_base_url(task: Task | None = None) -> str:
-    eff = effective_settings()["fofa"]
-    cfg = (task.fofa_config or {}) if task else {}
-    return str(cfg.get("base_url") or eff.get("base_url") or "https://fofa.info").rstrip("/")
+    """兼容旧版：等价于 resolve_engine_base_url('fofa', task)。"""
+    return resolve_engine_base_url("fofa", task)
 
 
 def resolve_fofa_defaults(task: Task | None = None) -> dict[str, Any]:
-    eff = effective_settings()["fofa"]
-    cfg = (task.fofa_config or {}) if task else {}
-    return {
-        "key": resolve_fofa_key(task),
-        "base_url": resolve_fofa_base_url(task),
-        "max_pages": int(cfg.get("max_pages") or eff.get("max_pages") or 20),
-        "page_size": int(cfg.get("page_size") or eff.get("page_size") or 100),
-        "intent_mode": str(cfg.get("intent_mode") or eff.get("default_intent_mode") or ""),
-    }
+    """兼容旧版。"""
+    return resolve_engine_config(task)
 
+
+# ── 其他 ──────────────────────────────────────────────────────
 
 def resolve_skip_score_threshold() -> float:
     return float(effective_settings()["defaults"].get("skip_score_threshold", -10))
@@ -131,6 +207,21 @@ def public_settings_view() -> dict[str, Any]:
     eff = effective_settings()
     llm = eff["llm"]
     fofa = eff["fofa"]
+    engines = eff.get("engines", {})
+    defaults = eff["defaults"]
+
+    # 构建引擎列表视图
+    engines_view = {}
+    for eng in list_engines():
+        name = eng["name"]
+        ecfg = engines.get(name, {})
+        engines_view[name] = {
+            "display_name": eng["display_name"],
+            "key": mask_secret(ecfg.get("key", "")),
+            "key_set": bool(ecfg.get("key")),
+            "base_url": ecfg.get("base_url", ""),
+        }
+
     return {
         "llm": {
             "base_url": llm["base_url"],
@@ -147,11 +238,14 @@ def public_settings_view() -> dict[str, Any]:
             "key": mask_secret(fofa.get("key") or ""),
             "key_set": bool(fofa.get("key")),
         },
+        "engines": engines_view,
         "defaults": {
-            "concurrency": int(eff["defaults"].get("concurrency") or 3),
-            "skip_score_threshold": float(eff["defaults"].get("skip_score_threshold", -10)),
-            "worker_prompt_version": normalize_worker_prompt_version(eff["defaults"].get("worker_prompt_version")),
+            "concurrency": int(defaults.get("concurrency") or 3),
+            "skip_score_threshold": float(defaults.get("skip_score_threshold", -10)),
+            "worker_prompt_version": normalize_worker_prompt_version(defaults.get("worker_prompt_version")),
+            "engine": defaults.get("engine", get_default_engine()),
         },
+        "available_engines": list_engines(),
         "updated_at": _cache.get("updated_at"),
     }
 
@@ -167,6 +261,7 @@ async def refresh_cache(session: AsyncSession) -> SystemSettings:
     _cache = {
         "llm": dict(row.llm or {}),
         "fofa": dict(row.fofa or {}),
+        "engines": dict(row.engines or {}),
         "defaults": dict(row.defaults or {}),
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
     }
@@ -188,7 +283,6 @@ async def update_settings(session: AsyncSession, payload: dict[str, Any]) -> dic
         llm = dict(row.llm or {})
         for k, v in payload["llm"].items():
             if k == "api_key":
-                # 空值或前端回显的脱敏占位都视为“未修改”，保留已存真实密钥。
                 if not str(v or "").strip() or is_masked_secret(v):
                     continue
             if v is not None:
@@ -204,6 +298,23 @@ async def update_settings(session: AsyncSession, payload: dict[str, Any]) -> dic
             if v is not None:
                 fofa[k] = v
         row.fofa = fofa
+
+    # 多引擎配置
+    if "engines" in payload and payload["engines"]:
+        engines = dict(row.engines or {})
+        for eng_name, eng_cfg in payload["engines"].items():
+            if not isinstance(eng_cfg, dict):
+                continue
+            current = dict(engines.get(eng_name, {}))
+            for k, v in eng_cfg.items():
+                if k == "key":
+                    if not str(v or "").strip() or is_masked_secret(v):
+                        continue
+                if v is not None:
+                    current[k] = v
+            if current:
+                engines[eng_name] = current
+        row.engines = engines
 
     if "defaults" in payload and payload["defaults"]:
         defaults = dict(row.defaults or {})
@@ -239,10 +350,7 @@ def llm_client_for_task_optional(task: Task | None = None):
 
 
 async def list_available_models(base_url: str | None = None, api_key: str | None = None) -> dict[str, Any]:
-    """拉取模型商可用模型列表（OpenAI 兼容 GET /models）。
-
-    base_url/api_key 留空时用有效配置（DB+env）。失败时返回 {ok:False, error, models:[]}，
-    前端可据此降级为手动输入。"""
+    """拉取模型商可用模型列表（OpenAI 兼容 GET /models）。"""
     import httpx
 
     eff = effective_settings()["llm"]
@@ -253,7 +361,6 @@ async def list_available_models(base_url: str | None = None, api_key: str | None
     if not key:
         return {"ok": False, "error": "未配置 API Key，无法拉取模型列表", "models": []}
     url = base if base.endswith("/models") else f"{base}/models"
-    # 该请求会携带真实 API Key，必须防 SSRF（防止 base_url 被篡改指向内网/元数据外泄密钥）。
     from app.tools.netguard import SsrfBlocked, assert_safe_outbound_url
 
     try:
@@ -269,7 +376,6 @@ async def list_available_models(base_url: str | None = None, api_key: str | None
         data = resp.json()
     except Exception as e:
         return {"ok": False, "error": f"拉取模型列表失败：{type(e).__name__}", "models": []}
-    # OpenAI 兼容：{"data":[{"id":"..."},...]}；也兜底 {"models":[...]} 等格式
     items = data.get("data") or data.get("models") or []
     models: list[str] = []
     for it in items:


### PR DESCRIPTION
## 新增功能

新增**多测绘搜索引擎抽象层**，支持动态切换 6 种常见测绘引擎：

| 引擎 | 标识 | 状态 |
|------|------|------|
| FOFA | `fofa` | ✅ 重构（原实现迁移至新架构） |
| 360 Quake | `quake` | ✅ 新增 |
| Hunter (鹰图) | `hunter` | ✅ 新增 |
| ZoomEye | `zoomeye` | ✅ 新增 |
| Shodan | `shodan` | ✅ 新增 |
| Censys | `censys` | ✅ 新增 |

## 改动说明

- `app/engines/` — 新增引擎抽象层（base.py + 注册表），各引擎独立文件
- `app/agents/collector.py` — 重构 `_fofa_collect` 为通用引擎搜集，支持动态切换
- `app/settings_service.py` — 新增多引擎配置解析（env + DB + 任务级覆盖），向后兼容
- `app/db/models.py` — Task 加 `engine` 字段，SystemSettings 加 `engines` 配置字段
- `app/api/dto.py` — 新增 EngineConfigDTO，CreateTaskRequest 支持传 engine
- `app/api/tasks.py` — 任务创建/更新支持引擎配置

## 配置方式

```bash
# .env 环境变量
SEARCH_ENGINE=quake  # 默认引擎
QUAKE_KEY=your_key
HUNTER_KEY=your_key
```

或通过控制台「设置」页配置各引擎 Key。

Closes #...