### PR TITLE
feat: 多测绘引擎支持 + 前端搜索引擎选择器

### DIFF
--- a/frontend/src/components/TaskEditModal.vue
+++ b/frontend/src/components/TaskEditModal.vue
@@ -41,6 +41,7 @@ const form = reactive({
   src_type: "edusrc",
   vuln_types: "",
   target_source: "fofa",
+  engine: "",
   fofa_query: "",
   intent_mode: "",
   manual_targets: "",
@@ -74,6 +75,7 @@ function fill(task) {
   form.src_type = task.src_type || "edusrc";
   form.vuln_types = (task.vuln_types || []).join(",");
   form.target_source = task.target_source || "fofa";
+  form.engine = task.engine || "";
   form.fofa_query = task.fofa_query || "";
   form.intent_mode = fofaCfg.intent_mode || "";
   form.manual_targets = (task.manual_targets || []).join("\n");
@@ -129,6 +131,7 @@ async function save() {
     src_type: form.src_type,
     vuln_types: form.vuln_types.split(",").map((s) => s.trim()).filter(Boolean),
     target_source: form.target_source,
+    engine: form.engine,
     fofa_query: form.fofa_query,
     manual_targets: form.manual_targets.split("\n").map((s) => s.trim()).filter(Boolean),
     src_rules: form.src_rules,
@@ -166,6 +169,17 @@ async function save() {
             <option value="manual">手动清单</option>
             <option value="both">两者</option>
             <option value="site">单站协作</option>
+          </select>
+        </label>
+        <label v-if="!isSiteMode">搜索引擎
+          <select v-model="form.engine">
+            <option value="">默认引擎</option>
+            <option value="fofa">FOFA</option>
+            <option value="quake">360 Quake</option>
+            <option value="hunter">Hunter (鹰图)</option>
+            <option value="zoomeye">ZoomEye</option>
+            <option value="shodan">Shodan</option>
+            <option value="censys">Censys</option>
           </select>
         </label>
         <label v-if="!isSiteMode">搜集方式

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1052,6 +1052,12 @@ main {
   background: var(--bg); border: 1px solid var(--border-soft); border-radius: 999px;
   padding: 5px 10px; font-size: 12px;
 }
+.mission-meta .engine-badge {
+  background: color-mix(in oklch, var(--accent) 15%, var(--bg));
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
 .mission-runtime {
   display: flex; flex-wrap: wrap; gap: 8px;
   margin-top: 10px;

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -738,6 +738,14 @@ const targetSourceName = computed(() => (({
   both: "FOFA+手动",
   site: "单站协作",
 })[task.value?.target_source] || task.value?.target_source || "-"));
+const engineName = computed(() => (({
+  fofa: "FOFA",
+  quake: "360 Quake",
+  hunter: "Hunter",
+  zoomeye: "ZoomEye",
+  shodan: "Shodan",
+  censys: "Censys",
+})[task.value?.engine] || task.value?.engine || "FOFA"));
 const missionScopeText = computed(() => {
   if (task.value?.target_source === "site") {
     return task.value?.fofa_query || task.value?.manual_targets?.[0] || "单站协作";
@@ -854,6 +862,7 @@ function parseEventTs(ts) {
         <div class="mission-meta">
           <span>{{ taskModeName }}</span>
           <span>{{ targetSourceName }}</span>
+          <span v-if="task.engine && task.engine !== 'fofa'" class="engine-badge">🔍 {{ engineName }}</span>
           <span>{{ missionScopeText }}</span>
           <span>并发 {{ task.concurrency }}</span>
           <span>{{ runState.hint }}</span>

--- a/frontend/src/views/CreateView.vue
+++ b/frontend/src/views/CreateView.vue
@@ -10,6 +10,7 @@ const form = reactive({
   src_type: "edusrc",
   vuln_types: "sql_injection,rce,unauthorized_access,idor,file_upload,captcha_bypass",
   target_source: "fofa",
+  engine: "",
   fofa_query: "",
   intent_mode: "",
   manual_targets: "",
@@ -47,6 +48,7 @@ async function submit() {
     src_type: form.src_type,
     vuln_types: form.vuln_types.split(",").map((s) => s.trim()).filter(Boolean),
     target_source: form.target_source,
+    engine: form.engine,
     fofa_query: form.fofa_query,
     manual_targets: form.manual_targets.split("\n").map((s) => s.trim()).filter(Boolean),
     src_rules: form.src_rules,
@@ -100,6 +102,17 @@ onMounted(async () => {
           <option value="manual">手动清单</option>
           <option value="both">两者</option>
           <option value="site">单站协作</option>
+        </select>
+      </label>
+      <label v-if="!isSiteMode">搜索引擎
+        <select v-model="form.engine">
+          <option value="">默认引擎</option>
+          <option value="fofa">FOFA</option>
+          <option value="quake">360 Quake</option>
+          <option value="hunter">Hunter (鹰图)</option>
+          <option value="zoomeye">ZoomEye</option>
+          <option value="shodan">Shodan</option>
+          <option value="censys">Censys</option>
         </select>
       </label>
       <label v-if="!isSiteMode">搜集方式


### PR DESCRIPTION
## 功能

1. **多搜索引擎支持** — 新增 360 Quake、Hunter (鹰图)、ZoomEye、Shodan、Censys 五个引擎
2. **插件架构** — 抽象基类 `SearchEngine` + 注册表模式，新增引擎只需写一个类
3. **FOFA 语法自动翻译** — 将 FOFA 查询语法自动翻译为各引擎原生语法
4. **前端搜索引擎选择器** — 创建任务、编辑任务、工作台均可选择/显示搜索引擎

## 变更文件

- `app/engines/` — 引擎抽象基类 + 6 个引擎实现 + 语法翻译器
- `app/settings_service.py` — 多引擎配置管理
- `app/agents/collector.py` — 引擎抽象集成
- `app/api/dto.py` — 引擎配置 DTO
- `app/api/tasks.py` — 引擎字段 CRUD
- `app/db/models.py` — 数据库引擎字段
- `frontend/` — 搜索引擎选择器 UI