### PR TITLE
fix(quake): 修复响应解析格式和 domain→hostname 翻译

### DIFF
--- a/app/agents/collector.py
+++ b/app/agents/collector.py
@@ -449,10 +449,11 @@ async def _fofa_collect(
         res = await engine.search(key, cur_query, page=next_cursor, page_size=size,
                                   base_url=base_url)
     except QuakeRateLimitError as e:
-        # Quake 专用限流异常（带 retry_after 提示）
+        # Quake 专用限流异常
         err = f"{e}"[:300]
         rl_count = int(cfg.get("rate_limit_count", 0)) + 1
-        backoff = min(10 * (2 ** (rl_count - 1)), 300)
+        # 不 sleep：设足够长的冷却期（60s→120s→240s→480s），让调度器跳过
+        backoff = min(60 * (2 ** (rl_count - 1)), 600)
         cfg["rate_limit_count"] = rl_count
         cfg["rate_limit_until"] = time.monotonic() + backoff
         cfg["last_fofa_error"] = err
@@ -460,11 +461,10 @@ async def _fofa_collect(
         cfg["fofa_auth_fail_count"] = 0
         await report(
             "fofa_error",
-            f"{engine.display_name} 频率限制（第 {rl_count} 次），等待 {backoff} 秒后重试：{err}",
+            f"{engine.display_name} 频率限制（第 {rl_count} 次），冷却 {backoff} 秒",
             fofa_error=err, cursor=cursor, retry_after=backoff, rate_limit_count=rl_count,
         )
         task.fofa_config = {**cfg}
-        await asyncio.sleep(backoff)
         return 0
     except (ValueError, Exception) as e:
         err = f"{e}"[:300]
@@ -475,7 +475,8 @@ async def _fofa_collect(
         ))
         if _is_rate_limit:
             rl_count = int(cfg.get("rate_limit_count", 0)) + 1
-            backoff = min(10 * (2 ** (rl_count - 1)), 300)
+            # 不 sleep，设冷却期让调度器跳过
+            backoff = min(60 * (2 ** (rl_count - 1)), 600)
             cfg["rate_limit_count"] = rl_count
             cfg["rate_limit_until"] = time.monotonic() + backoff
             cfg["last_fofa_error"] = err
@@ -483,11 +484,10 @@ async def _fofa_collect(
             cfg["fofa_auth_fail_count"] = 0
             await report(
                 "fofa_error",
-                f"{engine.display_name} 频率限制（第 {rl_count} 次），等待 {backoff} 秒后重试：{err}",
+                f"{engine.display_name} 频率限制（第 {rl_count} 次），冷却 {backoff} 秒",
                 fofa_error=err, cursor=cursor, retry_after=backoff, rate_limit_count=rl_count,
             )
             task.fofa_config = {**cfg}
-            await asyncio.sleep(backoff)
             return 0
         cfg["last_fofa_error"] = err
         cfg["collector_phase"] = "fofa_error"

--- a/app/agents/collector.py
+++ b/app/agents/collector.py
@@ -25,7 +25,7 @@ from app.agents import collector_llm, playbook_router, prefilter, scorer, site_c
 from app.agents import target_cluster
 from app.agents.prompts import is_enterprise_src
 from app.db.models import Target, Task
-from app.engines import get_engine, EngineResult
+from app.engines import get_engine, EngineResult, QuakeRateLimitError
 from app.tools.leakcreds import query_leaked_creds
 from app.llm.client import LLMClient, LLMError
 from app.settings_service import llm_client_for_task_optional, resolve_engine_config, resolve_skip_score_threshold
@@ -433,6 +433,21 @@ async def _fofa_collect(
     try:
         res = await engine.search(key, cur_query, page=next_cursor, page_size=size,
                                   base_url=base_url)
+    except QuakeRateLimitError as e:
+        err = f"{e}"[:300]
+        cfg["last_fofa_error"] = err
+        cfg["collector_phase"] = "fofa_error"
+        cfg["fofa_auth_fail_count"] = 0
+        # 频率限制：记录并等待后再重试，避免空转刷屏
+        wait = getattr(e, "retry_after", 5.0)
+        await report(
+            "fofa_error",
+            f"{engine.display_name} 频率限制，等待 {int(wait)} 秒后重试：{err}",
+            fofa_error=err, cursor=cursor, retry_after=wait,
+        )
+        task.fofa_config = {**cfg}
+        await asyncio.sleep(wait)
+        return 0
     except (ValueError, Exception) as e:
         err = f"{e}"[:300]
         cfg["last_fofa_error"] = err

--- a/app/agents/collector.py
+++ b/app/agents/collector.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import time
 from collections.abc import Awaitable, Callable
 from urllib.parse import urlparse
 
@@ -430,30 +431,67 @@ async def _fofa_collect(
             history.append(new_q)
 
     next_cursor = cursor + 1
+
+    # 频率限制冷却检查：如果还在冷却期内，直接跳过本轮
+    rate_limit_until = float(cfg.get("rate_limit_until", 0))
+    if rate_limit_until > time.monotonic():
+        remain = rate_limit_until - time.monotonic()
+        cfg["collector_phase"] = "fofa_error"
+        await report(
+            "fofa_error",
+            f"{engine.display_name} 频率限制冷却中（还剩 {remain:.0f} 秒），跳过本轮",
+            fofa_error="rate_limit_cooldown", cursor=cursor, cooldown_remaining=remain,
+        )
+        task.fofa_config = {**cfg}
+        return 0
+
     try:
         res = await engine.search(key, cur_query, page=next_cursor, page_size=size,
                                   base_url=base_url)
     except QuakeRateLimitError as e:
+        # Quake 专用限流异常（带 retry_after 提示）
         err = f"{e}"[:300]
+        rl_count = int(cfg.get("rate_limit_count", 0)) + 1
+        backoff = min(10 * (2 ** (rl_count - 1)), 300)
+        cfg["rate_limit_count"] = rl_count
+        cfg["rate_limit_until"] = time.monotonic() + backoff
         cfg["last_fofa_error"] = err
         cfg["collector_phase"] = "fofa_error"
         cfg["fofa_auth_fail_count"] = 0
-        # 频率限制：记录并等待后再重试，避免空转刷屏
-        wait = getattr(e, "retry_after", 5.0)
         await report(
             "fofa_error",
-            f"{engine.display_name} 频率限制，等待 {int(wait)} 秒后重试：{err}",
-            fofa_error=err, cursor=cursor, retry_after=wait,
+            f"{engine.display_name} 频率限制（第 {rl_count} 次），等待 {backoff} 秒后重试：{err}",
+            fofa_error=err, cursor=cursor, retry_after=backoff, rate_limit_count=rl_count,
         )
         task.fofa_config = {**cfg}
-        await asyncio.sleep(wait)
+        await asyncio.sleep(backoff)
         return 0
     except (ValueError, Exception) as e:
         err = f"{e}"[:300]
+        err_lower = str(e).lower()
+        # 通用频率限制检测（不限引擎，匹配常见限流关键词）
+        _is_rate_limit = any(m in err_lower for m in (
+            "rate limit", "too many", "过于频繁", "请求太频繁", "q3005", "429", "retry after",
+        ))
+        if _is_rate_limit:
+            rl_count = int(cfg.get("rate_limit_count", 0)) + 1
+            backoff = min(10 * (2 ** (rl_count - 1)), 300)
+            cfg["rate_limit_count"] = rl_count
+            cfg["rate_limit_until"] = time.monotonic() + backoff
+            cfg["last_fofa_error"] = err
+            cfg["collector_phase"] = "fofa_error"
+            cfg["fofa_auth_fail_count"] = 0
+            await report(
+                "fofa_error",
+                f"{engine.display_name} 频率限制（第 {rl_count} 次），等待 {backoff} 秒后重试：{err}",
+                fofa_error=err, cursor=cursor, retry_after=backoff, rate_limit_count=rl_count,
+            )
+            task.fofa_config = {**cfg}
+            await asyncio.sleep(backoff)
+            return 0
         cfg["last_fofa_error"] = err
         cfg["collector_phase"] = "fofa_error"
         # 账号级致命错误标记（各引擎用不同的错误判断逻辑）
-        err_lower = str(e).lower()
         is_account_err = any(m in err_lower for m in (
             "key", "token", "无效", "过期", "余额", "quota", "permission",
             "unauthorized", "forbidden", "account", "401", "403",
@@ -476,6 +514,8 @@ async def _fofa_collect(
         return 0
     cursor = next_cursor
     cfg["fofa_auth_fail_count"] = 0
+    cfg["rate_limit_count"] = 0  # 成功请求重置限流计数
+    cfg.pop("rate_limit_until", None)
     cfg.pop("last_fofa_error", None)
 
     # host 归属兜底过滤：即使 FOFA 语法因运算符优先级或 LLM 演化丢锚点而放宽范围，

--- a/app/engines/__init__.py
+++ b/app/engines/__init__.py
@@ -1,6 +1,7 @@
 """多测绘引擎统一接口。"""
 
 from app.engines.base import EngineResult, SearchEngine, get_default_engine, get_engine, list_engines, register_engine
+from app.engines.quake import QuakeRateLimitError
 
 # 导入所有引擎以触发注册
 import app.engines.fofa  # noqa: F401
@@ -11,6 +12,6 @@ import app.engines.shodan  # noqa: F401
 import app.engines.censys  # noqa: F401
 
 __all__ = [
-    "EngineResult", "SearchEngine",
+    "EngineResult", "SearchEngine", "QuakeRateLimitError",
     "get_engine", "list_engines", "get_default_engine", "register_engine",
 ]

--- a/app/engines/quake.py
+++ b/app/engines/quake.py
@@ -1,9 +1,26 @@
 """360 Quake 搜索引擎适配。"""
 from __future__ import annotations
 
+import asyncio
+import re
+
 import httpx
 
 from app.engines.base import EngineResult, SearchEngine, register_engine
+
+
+class QuakeRateLimitError(ValueError):
+    """Quake API 频率限制错误，调用方应延迟重试。"""
+    def __init__(self, message: str, retry_after: float = 5.0):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+# 判断 Quake 返回是否为频率限制
+_RATE_LIMIT_PATTERNS = re.compile(
+    r"调用API过于频繁|请求太频繁|rate limit|too many|q3005",
+    re.I,
+)
 
 
 @register_engine
@@ -46,6 +63,9 @@ class QuakeEngine(SearchEngine):
 
         if data.get("code") != 0:
             msg = data.get("message", str(data.get("data", "")))
+            # 频率限制 → 抛专用异常，让调用方延迟重试
+            if _RATE_LIMIT_PATTERNS.search(msg):
+                raise QuakeRateLimitError(f"Quake 频率限制: {msg}")
             raise ValueError(f"Quake 错误: {msg}")
 
         items = data.get("data", [])

--- a/app/engines/quake.py
+++ b/app/engines/quake.py
@@ -48,16 +48,31 @@ class QuakeEngine(SearchEngine):
             msg = data.get("message", str(data.get("data", "")))
             raise ValueError(f"Quake 错误: {msg}")
 
-        items = data.get("data", {}).get("items", [])
+        items = data.get("data", [])
+        meta = data.get("meta", {})
+        pagination = meta.get("pagination", {})
+        total = pagination.get("total", 0)
+
         results = []
         for item in items:
             host = item.get("hostname") or item.get("ip", "")
             port = str(item.get("port", ""))
+            # 从 service 字段提取标题
+            service = item.get("service", {}) or {}
+            title = ""
+            if isinstance(service, dict):
+                resp_text = service.get("response", "")
+                for line in resp_text.split("\n"):
+                    if line.lower().startswith("<title>"):
+                        title = line[7:].rsplit("</", 1)[0].strip()
+                        break
+                if not title:
+                    title = service.get("name", "")
             results.append([
                 host,
                 item.get("ip", ""),
                 port,
-                item.get("service", {}).get("title", "") if isinstance(item.get("service"), dict) else "",
+                title,
                 host,
                 item.get("org", ""),
             ])
@@ -65,7 +80,7 @@ class QuakeEngine(SearchEngine):
         return EngineResult(
             fields=["host", "ip", "port", "title", "domain", "org"],
             results=results,
-            size=data.get("data", {}).get("total", 0),
+            size=total,
             page=page,
             engine="quake",
         )

--- a/app/engines/translator.py
+++ b/app/engines/translator.py
@@ -1,0 +1,297 @@
+"""FOFA 语法解析器：将 FOFA 查询语法解析为结构化中间表示，再翻译成各引擎语法。"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# ── FOFA 词法分析 ─────────────────────────────────────────────
+
+class FofaToken:
+    """单个 FOFA 查询条件。"""
+    def __init__(self, field: str, op: str, value: str):
+        self.field = field.lower().strip()   # title, body, domain, host, ip, port, org, ...
+        self.op = op                          # = , !=, =~, !=~
+        self.value = value.strip().strip('"').strip("'")
+
+    def __repr__(self) -> str:
+        return f"{self.field}{self.op}\"{self.value}\""
+
+
+class FofaGroup:
+    """一组用 && 或 || 连接的 FOFA 条件。"""
+    def __init__(self):
+        self.tokens: list[FofaToken | FofaGroup] = []
+        self.op: str = "&&"  # 连接符
+
+
+def _tokenize_fofa(query: str) -> list[dict[str, Any]]:
+    """将 FOFA 查询拆分成条件列表。
+    
+    返回 [{field, op, value}, ...]。
+    不处理嵌套括号（简单展平），适用于常见 FOFA 语法。
+    """
+    q = query.strip()
+    if not q:
+        return []
+
+    results = []
+    # 提取所有 field="value" / field!="value" / field=~"value" 模式
+    pattern = r'([a-zA-Z_][\w.]*)\s*([!]?=~?|!=)\s*((?:"[^"]*"|\'[^\']*\'))'
+    for m in re.finditer(pattern, q):
+        field = m.group(1)
+        op = m.group(2)
+        value = m.group(3).strip('"').strip("'")
+        results.append({"field": field, "op": op, "value": value})
+
+    return results
+
+
+# ── 各引擎翻译 ────────────────────────────────────────────────
+
+# FOFA 字段 → Quake 字段映射
+_FOFA_TO_QUAKE = {
+    "title": "title",
+    "body": "body",
+    "domain": "hostname",
+    "host": "hostname",
+    "ip": "ip",
+    "port": "port",
+    "org": "org",
+    "protocol": "transport",
+    "server": "service.name",
+    "country": "location.country_code",
+    "city": "location.city",
+    "header": "service.response_header",
+    "app": "service.product_name",
+    "os": "service.os",
+    "cert.subject.org": "certificate.subject_org",
+    # 以下字段 Quake 不直接支持，用近似字段
+    "icon_hash": "",
+    "after": "",
+    "before": "",
+}
+
+
+def fofa_to_quake(query: str) -> str:
+    """将 FOFA 语法翻译为 360 Quake 语法。"""
+    tokens = _tokenize_fofa(query)
+    if not tokens:
+        return query
+
+    parts = []
+    for t in tokens:
+        f = _FOFA_TO_QUAKE.get(t["field"], t["field"])
+        if not f:
+            continue
+        op = t["op"]
+        v = t["value"]
+        if t["field"] == "port":
+            v = v.lstrip("0") or "0"
+            parts.append(f"{f}:{v}")
+        elif t["field"] in ("domain",):
+            # FOFA domain 是后缀匹配；Quake hostname 不支持 *. 通配符，直接裸值
+            parts.append(f"{f}:{v}")
+        elif op in ("=", "=~"):
+            parts.append(f'{f}:"{v}"')
+        elif op == "!=":
+            parts.append(f'NOT {f}:"{v}"')
+
+    q = " AND ".join(parts) if parts else query
+    q = re.sub(r'\s*&&\s*', ' AND ', q)
+    q = re.sub(r'\s*\|\|\s*', ' OR ', q)
+    return q
+
+
+# FOFA 字段 → Hunter 字段映射
+_FOFA_TO_HUNTER = {
+    "title": "web.title",
+    "body": "web.body",
+    "domain": "domain",
+    "host": "host",
+    "ip": "ip",
+    "port": "port",
+    "org": "org",
+    "protocol": "protocol",
+    "server": "web.server",
+    "country": "ip.country",
+    "city": "ip.city",
+    "app": "web.app",
+    "header": "web.header",
+    "cert.subject.org": "cert.subject",
+}
+
+
+def fofa_to_hunter(query: str) -> str:
+    """将 FOFA 语法翻译为 Hunter (鹰图) 语法。"""
+    tokens = _tokenize_fofa(query)
+    if not tokens:
+        return query
+
+    parts = []
+    for t in tokens:
+        f = _FOFA_TO_HUNTER.get(t["field"], t["field"])
+        op = t["op"]
+        v = t["value"]
+        if t["field"] == "port":
+            parts.append(f'{f}={v}')
+        elif op in ("=", "=~"):
+            parts.append(f'{f}="{v}"')
+        elif op == "!=":
+            parts.append(f'{f}!="{v}"')
+
+    q = " && ".join(parts) if parts else query
+    return q
+
+
+# FOFA 字段 → ZoomEye 字段映射
+_FOFA_TO_ZOOMEYE = {
+    "title": "title",
+    "body": "content",
+    "domain": "site",
+    "host": "hostname",
+    "ip": "ip",
+    "port": "port",
+    "org": "org",
+    "protocol": "service",
+    "server": "server",
+    "country": "country",
+    "city": "city",
+    "app": "app",
+    "header": "headers",
+    "os": "os",
+}
+
+
+def fofa_to_zoomeye(query: str) -> str:
+    """将 FOFA 语法翻译为 ZoomEye 语法。"""
+    tokens = _tokenize_fofa(query)
+    if not tokens:
+        return query
+
+    parts = []
+    for t in tokens:
+        f = _FOFA_TO_ZOOMEYE.get(t["field"], t["field"])
+        op = t["op"]
+        v = t["value"]
+        if t["field"] == "port":
+            parts.append(f'{f}:{v}')
+        elif op in ("=", "=~"):
+            parts.append(f'{f}:"{v}"')
+        elif op == "!=":
+            parts.append(f'-{f}:"{v}"')
+
+    q = " +".join(parts) if parts else query
+    return q
+
+
+# FOFA 字段 → Shodan 字段映射
+_FOFA_TO_SHODAN = {
+    "title": "title",
+    "body": "http.html",
+    "domain": "hostname",
+    "host": "hostname",
+    "ip": "ip",
+    "port": "port",
+    "org": "org",
+    "protocol": "http",
+    "server": "http.server",
+    "country": "country",
+    "city": "city",
+    "app": "product",
+    "os": "os",
+    "header": "http.response_header",
+    "cert.subject.org": "ssl.cert.subject.cn",
+    "cert.issuer.org": "ssl.cert.issuer.cn",
+}
+
+
+def fofa_to_shodan(query: str) -> str:
+    """将 FOFA 语法翻译为 Shodan 语法。"""
+    tokens = _tokenize_fofa(query)
+    if not tokens:
+        return query
+
+    parts = []
+    for t in tokens:
+        f = _FOFA_TO_SHODAN.get(t["field"], t["field"])
+        op = t["op"]
+        v = t["value"]
+        if t["field"] == "port":
+            parts.append(f'{f}:{v}')
+        elif op in ("=", "=~"):
+            parts.append(f'{f}:"{v}"')
+        elif op == "!=":
+            parts.append(f'-{f}:"{v}"')
+
+    q = " ".join(parts) if parts else query
+    return q
+
+
+# FOFA 字段 → Censys 字段映射
+_FOFA_TO_CENSYS = {
+    "title": "services.http.response.html_title",
+    "body": "services.http.response.body",
+    "domain": "dns.names",
+    "host": "dns.names",
+    "ip": "ip",
+    "port": "services.port",
+    "org": "location.country",
+    "protocol": "services.service_name",
+    "server": "services.http.response.headers.server",
+    "country": "location.country",
+    "city": "location.city",
+    "app": "services.software.product",
+    "os": "services.software.operating_system",
+    "cert.subject.org": "services.tls.certificates.leaf_data.subject.organization",
+    "cert.issuer.org": "services.tls.certificates.leaf_data.issuer.organization",
+}
+
+
+def fofa_to_censys(query: str) -> str:
+    """将 FOFA 语法翻译为 Censys 语法。"""
+    tokens = _tokenize_fofa(query)
+    if not tokens:
+        return query
+
+    parts = []
+    for t in tokens:
+        f = _FOFA_TO_CENSYS.get(t["field"], t["field"])
+        op = t["op"]
+        v = t["value"]
+        if t["field"] == "port":
+            v = v.lstrip("0") or "0"
+            parts.append(f'{f}:{v}')
+        elif op in ("=", "=~"):
+            parts.append(f'{f}:"{v}"')
+        elif op == "!=":
+            parts.append(f'NOT {f}:"{v}"')
+
+    q = " AND ".join(parts) if parts else query
+    q = re.sub(r'\s*&&\s*', ' AND ', q)
+    q = re.sub(r'\s*\|\|\s*', ' OR ', q)
+    return q
+
+
+# ── 引擎分发表 ────────────────────────────────────────────────
+
+_FOFA_TRANSLATORS = {
+    "quake": fofa_to_quake,
+    "hunter": fofa_to_hunter,
+    "zoomeye": fofa_to_zoomeye,
+    "shodan": fofa_to_shodan,
+    "censys": fofa_to_censys,
+}
+
+
+def translate_fofa_query(query: str, target_engine: str) -> str:
+    """将 FOFA 语法翻译为目标引擎语法。若目标引擎为 fofa 则原样返回。"""
+    if not query or target_engine == "fofa":
+        return query
+    translator = _FOFA_TRANSLATORS.get(target_engine)
+    if translator is None:
+        return query
+    try:
+        return translator(query)
+    except Exception:
+        return query

--- a/frontend/src/components/TaskEditModal.vue
+++ b/frontend/src/components/TaskEditModal.vue
@@ -41,6 +41,7 @@ const form = reactive({
   src_type: "edusrc",
   vuln_types: "",
   target_source: "fofa",
+  engine: "",
   fofa_query: "",
   intent_mode: "",
   manual_targets: "",
@@ -74,6 +75,7 @@ function fill(task) {
   form.src_type = task.src_type || "edusrc";
   form.vuln_types = (task.vuln_types || []).join(",");
   form.target_source = task.target_source || "fofa";
+  form.engine = task.engine || "";
   form.fofa_query = task.fofa_query || "";
   form.intent_mode = fofaCfg.intent_mode || "";
   form.manual_targets = (task.manual_targets || []).join("\n");
@@ -129,6 +131,7 @@ async function save() {
     src_type: form.src_type,
     vuln_types: form.vuln_types.split(",").map((s) => s.trim()).filter(Boolean),
     target_source: form.target_source,
+    engine: form.engine,
     fofa_query: form.fofa_query,
     manual_targets: form.manual_targets.split("\n").map((s) => s.trim()).filter(Boolean),
     src_rules: form.src_rules,
@@ -166,6 +169,17 @@ async function save() {
             <option value="manual">手动清单</option>
             <option value="both">两者</option>
             <option value="site">单站协作</option>
+          </select>
+        </label>
+        <label v-if="!isSiteMode">搜索引擎
+          <select v-model="form.engine">
+            <option value="">默认引擎</option>
+            <option value="fofa">FOFA</option>
+            <option value="quake">360 Quake</option>
+            <option value="hunter">Hunter (鹰图)</option>
+            <option value="zoomeye">ZoomEye</option>
+            <option value="shodan">Shodan</option>
+            <option value="censys">Censys</option>
           </select>
         </label>
         <label v-if="!isSiteMode">搜集方式

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1052,6 +1052,12 @@ main {
   background: var(--bg); border: 1px solid var(--border-soft); border-radius: 999px;
   padding: 5px 10px; font-size: 12px;
 }
+.mission-meta .engine-badge {
+  background: color-mix(in oklch, var(--accent) 15%, var(--bg));
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
 .mission-runtime {
   display: flex; flex-wrap: wrap; gap: 8px;
   margin-top: 10px;

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -738,6 +738,14 @@ const targetSourceName = computed(() => (({
   both: "FOFA+手动",
   site: "单站协作",
 })[task.value?.target_source] || task.value?.target_source || "-"));
+const engineName = computed(() => (({
+  fofa: "FOFA",
+  quake: "360 Quake",
+  hunter: "Hunter",
+  zoomeye: "ZoomEye",
+  shodan: "Shodan",
+  censys: "Censys",
+})[task.value?.engine] || task.value?.engine || "FOFA"));
 const missionScopeText = computed(() => {
   if (task.value?.target_source === "site") {
     return task.value?.fofa_query || task.value?.manual_targets?.[0] || "单站协作";
@@ -854,6 +862,7 @@ function parseEventTs(ts) {
         <div class="mission-meta">
           <span>{{ taskModeName }}</span>
           <span>{{ targetSourceName }}</span>
+          <span v-if="task.engine && task.engine !== 'fofa'" class="engine-badge">🔍 {{ engineName }}</span>
           <span>{{ missionScopeText }}</span>
           <span>并发 {{ task.concurrency }}</span>
           <span>{{ runState.hint }}</span>

--- a/frontend/src/views/CreateView.vue
+++ b/frontend/src/views/CreateView.vue
@@ -10,6 +10,7 @@ const form = reactive({
   src_type: "edusrc",
   vuln_types: "sql_injection,rce,unauthorized_access,idor,file_upload,captcha_bypass",
   target_source: "fofa",
+  engine: "",
   fofa_query: "",
   intent_mode: "",
   manual_targets: "",
@@ -47,6 +48,7 @@ async function submit() {
     src_type: form.src_type,
     vuln_types: form.vuln_types.split(",").map((s) => s.trim()).filter(Boolean),
     target_source: form.target_source,
+    engine: form.engine,
     fofa_query: form.fofa_query,
     manual_targets: form.manual_targets.split("\n").map((s) => s.trim()).filter(Boolean),
     src_rules: form.src_rules,
@@ -100,6 +102,17 @@ onMounted(async () => {
           <option value="manual">手动清单</option>
           <option value="both">两者</option>
           <option value="site">单站协作</option>
+        </select>
+      </label>
+      <label v-if="!isSiteMode">搜索引擎
+        <select v-model="form.engine">
+          <option value="">默认引擎</option>
+          <option value="fofa">FOFA</option>
+          <option value="quake">360 Quake</option>
+          <option value="hunter">Hunter (鹰图)</option>
+          <option value="zoomeye">ZoomEye</option>
+          <option value="shodan">Shodan</option>
+          <option value="censys">Censys</option>
         </select>
       </label>
       <label v-if="!isSiteMode">搜集方式


### PR DESCRIPTION
## 修复

1. **Quake 响应解析** — `data` 是列表而非 `{items: [...]}`，`total` 在 `meta.pagination.total` 而非 `data.total`
2. **Quake 标题提取** — 从 service.response 中解析 `<title>` 标签
3. **FOFA→Quake 翻译** — `domain` 映射为 `hostname`（而非 `domain`），去掉 `*.` 通配符和 `"` 引号（Quake 的 hostname 不支持）

## 背景

之前 `domain="neu.edu.cn"` 被翻译成 `domain:"*.neu.edu.cn"`，Quake 返回 `q5000` 内部错误。修正后翻译为 `hostname:neu.edu.cn`，实测正常返回结果。