### PR TITLE
feat(llm): 增加模型端点池与任务级模型调度

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,18 @@ LLM_MAX_TOKENS=4096
 # 并抹掉 x-stainless-* 指纹头，绕过部分中转站/2api 网关（Cloudflare WAF）对 SDK UA 的 403 封禁。
 # 可选覆盖：browser=伪装 Chrome；auto=按模型自动；或直接写任意固定串，如 curl/8.7.1。
 # LLM_USER_AGENT=auto
+# single 使用上面的单端点；pool 使用 LLM_PROVIDERS_JSON 中的完整启用端点。
+LLM_PROVIDER_MODE=single
+# auto / openai_chat / anthropic_messages
+LLM_PROTOCOL=auto
+# JSON 数组；每项支持 name/base_url/api_key/model/protocol/temperature/weight/enabled。
+LLM_PROVIDERS_JSON=[]
+# 连续失败达到阈值后进入分级冷却，逗号分隔的秒数会随连续熔断次数递进。
+LLM_PROVIDER_FAIL_THRESHOLD=5
+LLM_PROVIDER_BEHAVIOR_FAIL_THRESHOLD=3
+LLM_PROVIDER_FAILED_RETRY_SECONDS=60
+LLM_PROVIDER_BEHAVIOR_PROBE_SECONDS=900
+LLM_PROVIDER_COOLDOWN_SECONDS=300,900,1800,3600
 
 # ---------------------------------------------------------------------------
 # 【推荐】FOFA 网络空间测绘 Key（用于自动搜集目标资产；不填则只能手动录入目标）

--- a/app/agents/collector.py
+++ b/app/agents/collector.py
@@ -233,8 +233,8 @@ def _is_cluster_deadish(t: Target) -> bool:
     return any(marker in reason for marker in ("无可利用", "无果", "自动收敛", "打不穿", "timeout", "超时"))
 
 
-def _llm_for_task(task: Task) -> LLMClient | None:
-    return llm_client_for_task_optional(task)
+def _llm_for_task(task: Task, on_provider_failure=None) -> LLMClient | None:
+    return llm_client_for_task_optional(task, on_provider_failure=on_provider_failure)
 
 
 async def _resolve_query(task: Task, llm: LLMClient | None) -> tuple[str, str]:
@@ -311,7 +311,8 @@ async def _resolve_query(task: Task, llm: LLMClient | None) -> tuple[str, str]:
 
 async def refill(session: AsyncSession, task: Task, low_watermark: int = 5,
                  batch_pages: int = 1,
-                 progress_cb: ProgressCallback | None = None) -> int:
+                 progress_cb: ProgressCallback | None = None,
+                 on_provider_failure=None) -> int:
     """补充目标。返回新入队数量。队列够则不补。"""
     queued = (await session.execute(
         select(func.count()).select_from(Target).where(
@@ -366,7 +367,9 @@ async def refill(session: AsyncSession, task: Task, low_watermark: int = 5,
 
     # 2) FOFA 智能搜集
     if task.target_source in ("fofa", "both"):
-        added += await _fofa_collect(session, task, seen, cluster_state, progress)
+        added += await _fofa_collect(
+            session, task, seen, cluster_state, progress, on_provider_failure
+        )
 
     await session.commit()
     return added
@@ -435,6 +438,7 @@ async def _fofa_collect(
     seen: set[str],
     cluster_state: dict[str, dict],
     progress: ProgressReporter | None = None,
+    on_provider_failure=None,
 ) -> int:
     async def report(phase: str, text: str, **payload) -> None:
         if progress:
@@ -454,7 +458,7 @@ async def _fofa_collect(
     size = int(defaults["page_size"])
     base_url = defaults.get("base_url") or engine.get_default_base_url()
 
-    llm = _llm_for_task(task)
+    llm = _llm_for_task(task, on_provider_failure=on_provider_failure)
     history: list[str] = list(cfg.get("history", []))
     cur_query = cfg.get("current_query", "")
     cursor = int(cfg.get("cursor", 0))

--- a/app/agents/worker.py
+++ b/app/agents/worker.py
@@ -19,7 +19,7 @@ from app.agents.prompts import is_enterprise_src, normalize_worker_prompt_versio
 from app.agents import auth_bootstrap
 from app.config import worker_config
 from app import dedup
-from app.llm.client import LLMClient
+from app.llm.client import LLMClient, LLMError
 from app.schemas import Finding, Verdict, WorkerResult
 from app.tools.executor import ToolExecutor
 from app.tools.schemas import (
@@ -262,9 +262,12 @@ class Worker:
                 msg = self.llm.chat(send_messages, tools=tools, tool_choice="auto")
             except Exception as e:
                 self._emit("llm_error", error=str(e))
+                failure_kind = e.kind if isinstance(e, LLMError) else ""
+                retry_after = e.retry_after if isinstance(e, LLMError) else 0
                 return WorkerResult(
                     target=self.target, verdict=Verdict.error,
                     findings=self.findings, rounds=rounds, error=f"LLM 调用失败: {e}",
+                    failure_kind=failure_kind, retry_after_seconds=retry_after,
                 )
             if self.cancel_event.is_set():
                 return self._cancelled_result(rounds)
@@ -302,7 +305,10 @@ class Worker:
             if not tool_calls:
                 no_tool_rounds += 1
                 if no_tool_rounds >= 6:
-                    self._auto_finish("模型连续 6 轮没有调用工具或 finish，系统自动收敛。")
+                    self._auto_finish(
+                        "模型连续 6 轮没有调用工具或 finish，本轮未得到可靠结论。",
+                        "model_behavior",
+                    )
                     break
                 # 没有工具调用也没结束，提醒模型继续或收尾
                 messages.append({"role": "user", "content": "继续调用工具验证，或 finish。"})
@@ -375,7 +381,10 @@ class Worker:
                     consecutive_blocked = 0
                     continue
                 if consecutive_arg_errors >= 3:
-                    self._auto_finish("连续 3 次工具参数错误，模型未修正，系统自动收敛。")
+                    self._auto_finish(
+                        "连续 3 次工具参数错误，模型未修正，本轮未得到可靠结论。",
+                        "tool_argument",
+                    )
                     break
                 if consecutive_network_failures >= 3:
                     self._auto_finish("连续 3 次网络/超时失败，目标当前不可稳定验证，系统自动收敛。")
@@ -445,7 +454,10 @@ class Worker:
             findings=self.findings,
             summary=(self._finished or {}).get("summary", ""),
             rounds=rounds,
-            error=None if self._finished else f"达到最大轮数 {max_rounds} 未主动结束",
+            error=(self._finished or {}).get("error") or (
+                None if self._finished else f"达到最大轮数 {max_rounds} 未主动结束"
+            ),
+            failure_kind=(self._finished or {}).get("failure_kind", ""),
             deepen_lead=(self._finished or {}).get("deepen_lead", ""),
             reported_intel=self._reported_intel,
             reported_coverage=self._reported_coverage,
@@ -664,6 +676,7 @@ class Worker:
                 "summary": args.get("summary", ""),
                 "deepen_lead": (args.get("deepen_lead") or "").strip(),
             }
+            self._report_provider_success()
             self._emit("worker_finish", verdict=self._finished["verdict"],
                        summary=self._finished["summary"][:300],
                        deepen_lead=self._finished["deepen_lead"][:300])
@@ -780,10 +793,45 @@ class Worker:
             return "参数格式错误：检查工具参数是否合法 JSON、必填字段是否齐全。对照工具 schema 修正后重试一次。"
         return ""
 
-    def _auto_finish(self, reason: str) -> None:
+    def _auto_finish(self, reason: str, failure_kind: str = "") -> None:
+        if failure_kind:
+            self._finished = {
+                "verdict": "error",
+                "summary": reason,
+                "error": reason,
+                "failure_kind": failure_kind,
+            }
+            self._report_provider_failure(reason, failure_kind)
+            self._emit(
+                "worker_auto_finish",
+                verdict="error",
+                failure_kind=failure_kind,
+                summary=reason[:300],
+            )
+            return
         verdict = "found" if self.findings else "no_vuln"
         self._finished = {"verdict": verdict, "summary": reason}
         self._emit("worker_auto_finish", verdict=verdict, summary=reason[:300])
+
+    def _report_provider_failure(self, reason: str, failure_kind: str) -> None:
+        if failure_kind not in {"model_behavior", "tool_argument"}:
+            return
+        reporter = getattr(self.llm, "report_current_provider_failure", None)
+        if not reporter:
+            return
+        try:
+            reporter(reason, kind=failure_kind)
+        except Exception as exc:
+            self._emit("provider_degrade_error", error=str(exc), failure_kind=failure_kind)
+
+    def _report_provider_success(self) -> None:
+        reporter = getattr(self.llm, "report_current_provider_success", None)
+        if not reporter:
+            return
+        try:
+            reporter()
+        except Exception as exc:
+            self._emit("provider_health_error", error=str(exc))
 
     @staticmethod
     def _tool_outcome(result: dict) -> str:

--- a/app/api/dto.py
+++ b/app/api/dto.py
@@ -1,15 +1,17 @@
 """API 请求/响应 DTO。"""
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
 
 class ModelConfigDTO(BaseModel):
+    inherit_global: Optional[bool] = None
     base_url: str = "https://api.deepseek.com/v1"
     api_key: str = ""
     model: str = "deepseek-chat"
+    protocol: str = "auto"
     prompt_version: str = ""
 
 
@@ -57,10 +59,19 @@ class CreateTaskRequest(BaseModel):
 
 
 class PartialModelConfigDTO(BaseModel):
+    inherit_global: Optional[bool] = None
     base_url: Optional[str] = None
     api_key: Optional[str] = None
     model: Optional[str] = None
+    protocol: Optional[str] = None
     prompt_version: Optional[str] = None
+
+
+class TaskModelsProbeRequest(BaseModel):
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    key_ref: Optional[str] = None
+    protocol: Optional[str] = None
 
 
 class PartialFofaConfigDTO(BaseModel):
@@ -135,10 +146,13 @@ class TaskResponse(BaseModel):
 
 
 class LLMSettingsDTO(BaseModel):
+    mode: Optional[str] = None
     base_url: Optional[str] = None
     api_key: Optional[str] = None
     model: Optional[str] = None
+    protocol: Optional[str] = None
     temperature: Optional[float] = None
+    providers: Optional[list[dict[str, Any]]] = None
 
 
 class FofaSettingsDTO(BaseModel):

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -1,16 +1,32 @@
 """全局系统配置 API。"""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+import re
+import time
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dto import SettingsUpdateRequest
+from app.config import LLMConfig
 from app.db.session import get_session
+from app.llm.client import _resolve_user_agent
+from app.llm.health import mark_provider_failed, mark_provider_ok
+from app.tools.netguard import SsrfBlocked, assert_safe_outbound_url
 from app.settings_service import (
+    _clean_llm_providers,
+    _preserve_provider_keys,
+    effective_settings,
+    is_masked_secret,
     list_available_models,
+    normalize_llm_mode,
+    normalize_llm_protocol,
     public_settings_view,
     refresh_cache,
+    resolve_llm_key_for_identity,
+    resolve_llm_key_ref,
+    resolve_llm_providers,
     update_settings,
 )
 
@@ -26,6 +42,9 @@ async def get_settings(session: AsyncSession = Depends(get_session)):
 class ModelsProbeRequest(BaseModel):
     base_url: str | None = None
     api_key: str | None = None
+    protocol: str | None = None
+    key_ref: str | None = None
+    model: str | None = None
 
 
 @router.post("/models")
@@ -37,9 +56,230 @@ async def probe_models(
     注意：api_key 为脱敏占位（如 ****）时视为未传，回退到服务端已存的真实 key。"""
     await refresh_cache(session)
     key = (body.api_key or "").strip()
-    if key and set(key) <= {"*", "•", "·", "●"}:
+    if key and is_masked_secret(key):
         key = ""  # 前端回显的脱敏占位，丢弃
-    return await list_available_models(base_url=body.base_url, api_key=key or None)
+    return await list_available_models(
+        base_url=body.base_url,
+        api_key=key or None,
+        protocol=body.protocol,
+        key_ref=body.key_ref,
+        model=body.model,
+    )
+
+
+@router.get("/provider-health")
+async def get_provider_health(session: AsyncSession = Depends(get_session)):
+    await refresh_cache(session)
+    llm = public_settings_view()["llm"]
+    return {
+        "mode": llm.get("mode", "single"),
+        "single": {
+            "health_ref": llm.get("health_ref", ""),
+            "health": llm.get("health", {}),
+        },
+        "providers": [
+            {
+                "name": item.get("name", ""),
+                "base_url": item.get("base_url", ""),
+                "model": item.get("model", ""),
+                "protocol": item.get("protocol", "auto"),
+                "health_ref": item.get("health_ref", ""),
+                "health": item.get("health", {}),
+            }
+            for item in llm.get("providers", [])
+        ],
+    }
+
+
+class LLMTestRequest(BaseModel):
+    base_url: str | None = None
+    api_key: str | None = None
+    key_ref: str | None = None
+    model: str | None = None
+    protocol: str | None = None
+    temperature: float | None = None
+    providers: list[dict] | None = None
+
+
+_TEST_SECRET_RE = re.compile(
+    r"(?:\bsk-[A-Za-z0-9_-]{8,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{8,})",
+    re.IGNORECASE,
+)
+
+
+_NAMED_SECRET_RE = re.compile(
+    r"((?:api[_-]?key|x-api-key|token|secret|password|passwd|pwd)"
+    r"\s*[\"']?\s*[:=]\s*[\"']?)[^\s,;\"']+",
+    re.IGNORECASE,
+)
+
+
+def _safe_error(value: object, *secrets: str) -> str:
+    text = " ".join(str(value or "").split())
+    for secret in secrets:
+        if secret:
+            text = text.replace(str(secret), "<masked>")
+    text = _NAMED_SECRET_RE.sub(r"\1<masked>", text)
+    return _TEST_SECRET_RE.sub("<masked>", text)[:500]
+
+
+def _api_root(base_url: str) -> str:
+    base = str(base_url or "").strip().rstrip("/")
+    lowered = base.lower()
+    for suffix in ("/chat/completions", "/messages"):
+        if lowered.endswith(suffix):
+            return base[: -len(suffix)].rstrip("/")
+    return base
+
+
+def _chat_url(base_url: str, protocol: str) -> str:
+    base = _api_root(base_url)
+    path = "messages" if protocol == "anthropic_messages" else "chat/completions"
+    return f"{base}/{path}" if base.lower().endswith("/v1") else f"{base}/v1/{path}"
+
+
+def _test_configs(body: LLMTestRequest) -> list[tuple[str, LLMConfig]]:
+    eff = effective_settings()["llm"]
+    old_providers = _clean_llm_providers(eff.get("providers") or [])
+    if body.providers is not None:
+        items = _clean_llm_providers(_preserve_provider_keys(body.providers, old_providers))
+        return [
+            (
+                str(item.get("name") or f"llm-{index + 1}"),
+                LLMConfig(
+                    base_url=item["base_url"],
+                    api_key=item["api_key"],
+                    model=item["model"],
+                    protocol=item["protocol"],
+                    temperature=float(item["temperature"]),
+                    weight=int(item["weight"]),
+                    enabled=bool(item["enabled"]),
+                ),
+            )
+            for index, item in enumerate(items)
+            if item.get("enabled", True)
+        ]
+
+    explicit_single = any((body.base_url, body.api_key, body.key_ref, body.model, body.protocol))
+    if explicit_single:
+        base_url = body.base_url or eff.get("base_url") or ""
+        model = body.model or eff.get("model") or ""
+        protocol = normalize_llm_protocol(body.protocol or eff.get("protocol"))
+        api_key = str(body.api_key or "").strip()
+        if not api_key or is_masked_secret(api_key):
+            api_key = resolve_llm_key_ref(
+                body.key_ref, base_url, model, protocol
+            ) or resolve_llm_key_for_identity(base_url, model, protocol)
+        return [("single", LLMConfig(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            protocol=protocol,
+            temperature=float(body.temperature if body.temperature is not None else eff.get("temperature") or 0.3),
+        ))]
+
+    return [
+        (f"llm-{index + 1}", config)
+        for index, config in enumerate(resolve_llm_providers())
+    ]
+
+
+async def _test_llm_one(name: str, provider: LLMConfig) -> dict:
+    import httpx
+
+    protocol = normalize_llm_protocol(provider.protocol)
+    if protocol == "auto":
+        lowered = provider.base_url.lower()
+        protocol = "anthropic_messages" if "anthropic" in lowered or "/messages" in lowered else "openai_chat"
+    url = _chat_url(provider.base_url, protocol)
+    result = {
+        "name": name,
+        "ok": False,
+        "base_url": provider.base_url,
+        "model": provider.model,
+        "protocol": protocol,
+        "status_code": 0,
+        "latency_ms": 0,
+        "error": "",
+    }
+    if not provider.api_key:
+        result["error"] = "未配置 API Key"
+        return result
+    try:
+        assert_safe_outbound_url(url)
+    except SsrfBlocked as exc:
+        result["error"] = f"base_url 不被允许：{exc}"
+        return result
+
+    headers = {
+        "Authorization": f"Bearer {provider.api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": _resolve_user_agent(provider.model, provider.base_url),
+    }
+    payload = {
+        "model": provider.model,
+        "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
+        "temperature": 0,
+        "max_tokens": 8,
+    }
+    if protocol == "anthropic_messages":
+        headers.update({
+            "x-api-key": provider.api_key,
+            "anthropic-version": "2023-06-01",
+        })
+
+    started = time.perf_counter()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            if response.status_code == 400 and "max_tokens" in response.text.lower():
+                payload.pop("max_tokens", None)
+                response = await client.post(url, headers=headers, json=payload)
+        result["latency_ms"] = int((time.perf_counter() - started) * 1000)
+        result["status_code"] = response.status_code
+        if response.status_code >= 400:
+            result["error"] = _safe_error(
+                f"HTTP {response.status_code}: {response.text[:300]}", provider.api_key
+            )
+            mark_provider_failed(
+                provider.base_url, provider.model, result["error"], provider.api_key,
+                provider.protocol, kind="probe"
+            )
+            return result
+        data = response.json()
+        if protocol == "anthropic_messages":
+            reply = "".join(
+                str(block.get("text") or "")
+                for block in data.get("content") or []
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        else:
+            choice = (data.get("choices") or [{}])[0]
+            reply = str((choice.get("message") or {}).get("content") or choice.get("text") or "")
+        result.update(ok=True, reply=reply[:80])
+        mark_provider_ok(
+            provider.base_url, provider.model, provider.api_key, provider.protocol
+        )
+        return result
+    except Exception as exc:
+        result["latency_ms"] = int((time.perf_counter() - started) * 1000)
+        result["error"] = _safe_error(exc, provider.api_key)
+        mark_provider_failed(
+            provider.base_url, provider.model, result["error"], provider.api_key,
+            provider.protocol, kind="probe"
+        )
+        return result
+
+
+@router.post("/test-llm")
+async def test_llm(body: LLMTestRequest, session: AsyncSession = Depends(get_session)):
+    await refresh_cache(session)
+    providers = _test_configs(body)
+    if not providers:
+        return {"ok": False, "results": [], "error": "未配置可用 LLM 端点"}
+    results = [await _test_llm_one(name, provider) for name, provider in providers]
+    return {"ok": all(item["ok"] for item in results), "results": results}
 
 
 @router.put("")
@@ -48,4 +288,19 @@ async def put_settings(
     session: AsyncSession = Depends(get_session),
 ):
     payload = body.model_dump(exclude_unset=True)
+    llm_update = payload.get("llm") or {}
+    if llm_update:
+        current_llm = effective_settings()["llm"]
+        mode = normalize_llm_mode(llm_update.get("mode", current_llm.get("mode")))
+        if mode == "pool":
+            old_providers = _clean_llm_providers(current_llm.get("providers") or [])
+            incoming = llm_update.get("providers", current_llm.get("providers") or [])
+            providers = _clean_llm_providers(
+                _preserve_provider_keys(incoming, old_providers)
+            )
+            if not any(item.get("enabled", True) for item in providers):
+                raise HTTPException(
+                    status_code=400,
+                    detail="端点池模式至少需要一个配置完整且已启用的 LLM 端点",
+                )
     return await update_settings(session, payload)

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -7,7 +7,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import case, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.dto import CreateTaskRequest, TaskResponse, TaskStats, UpdateTaskRequest
+from app.api.dto import (
+    CreateTaskRequest,
+    TaskModelsProbeRequest,
+    TaskResponse,
+    TaskStats,
+    UpdateTaskRequest,
+)
 from app.agents import site_collab
 from app.agents.prompts import normalize_src_type
 from app.db.models import Finding, Killsweep, Review, Target, Task, TaskEvent, to_cst_iso
@@ -15,7 +21,17 @@ from app.db.session import get_session
 from app.llm.usage import usage_snapshot
 from app.orchestrator import manager
 from app.security import resolve_role, token_from_headers
-from app.settings_service import resolve_engine_config, resolve_llm_config, resolve_worker_prompt_version
+from app.settings_service import (
+    _llm_identity,
+    is_masked_secret,
+    list_available_models,
+    normalize_llm_protocol,
+    resolve_engine_config,
+    resolve_llm_config,
+    resolve_llm_providers,
+    resolve_worker_prompt_version,
+    secret_ref,
+)
 
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
@@ -55,6 +71,17 @@ def _observer_fofa_config() -> dict:
         "key_set": False, "current_query": "", "cursor": 0,
         "collector_phase": "", "collector_phase_text": "",
     }
+
+
+def _model_inherits_global(cfg: dict) -> bool:
+    if cfg.get("inherit_global") is not None:
+        return bool(cfg.get("inherit_global"))
+    if cfg.get("providers"):
+        return False
+    return not any(
+        str(cfg.get(key) or "").strip()
+        for key in ("api_key", "providers_json", "base_url", "model", "protocol")
+    )
 
 
 def _mask_label(label: str) -> str:
@@ -121,11 +148,16 @@ def _observer_ip(ip: str) -> str:
 
 def _public_model_config(task: Task) -> dict:
     cfg = resolve_llm_config(task)
+    raw_cfg = dict(task.model_config_json or {})
     return {
         "base_url": cfg.base_url,
         "model": cfg.model,
+        "protocol": cfg.protocol,
         "api_key_set": bool(cfg.api_key),
+        "key_ref": secret_ref(cfg.api_key),
+        "provider_count": len(resolve_llm_providers(task)),
         "prompt_version": resolve_worker_prompt_version(task),
+        "inherit_global": _model_inherits_global(raw_cfg),
     }
 
 
@@ -280,12 +312,28 @@ async def create_task(req: CreateTaskRequest, session: AsyncSession = Depends(ge
         fofa_cfg["key"] = eng_cfg["key"]
     if eng_cfg.get("base_url"):
         fofa_cfg["base_url"] = eng_cfg["base_url"]
+    inherit_global = req.model_config_data.inherit_global
+    if inherit_global is None:
+        inherit_global = not bool(
+            req.model_config_data.model_fields_set
+            & {"base_url", "api_key", "model", "protocol"}
+        )
+    if inherit_global:
+        model_config = req.model_config_data.model_dump(exclude_defaults=True)
+        model_config = {k: v for k, v in model_config.items() if k == "prompt_version"}
+        model_config["inherit_global"] = True
+    else:
+        model_config = req.model_config_data.model_dump(
+            exclude={"inherit_global"},
+            exclude_unset=True,
+        )
+        model_config["inherit_global"] = False
     task = Task(
         name=req.name, src_type=normalize_src_type(req.src_type), vuln_types=req.vuln_types,
         src_rules=req.src_rules, target_source=req.target_source,
         engine=engine_name, fofa_query=req.fofa_query, manual_targets=req.manual_targets,
         auth_bindings=_dump_auth_bindings(req.auth_bindings),
-        model_config_json=req.model_config_data.model_dump(exclude_defaults=True),
+        model_config_json=model_config,
         fofa_config=fofa_cfg, concurrency=req.concurrency,
         status="created",
     )
@@ -293,6 +341,36 @@ async def create_task(req: CreateTaskRequest, session: AsyncSession = Depends(ge
     await session.commit()
     await session.refresh(task)
     return _task_to_dto(task)
+
+
+@router.post("/{task_id}/models")
+async def probe_task_models(
+    task_id: str,
+    body: TaskModelsProbeRequest,
+    session: AsyncSession = Depends(get_session),
+):
+    task = await session.get(Task, task_id)
+    if not task:
+        raise HTTPException(404, "任务不存在")
+    config = resolve_llm_config(task)
+    base_url = str(body.base_url or config.base_url or "").strip()
+    protocol = normalize_llm_protocol(body.protocol or config.protocol)
+    api_key = str(body.api_key or "").strip()
+    if is_masked_secret(api_key):
+        api_key = ""
+    if not api_key:
+        same_identity = _llm_identity(base_url, protocol) == _llm_identity(
+            config.base_url, config.protocol
+        )
+        same_ref = bool(body.key_ref and body.key_ref == secret_ref(config.api_key))
+        if not (same_identity and same_ref):
+            return {"ok": False, "error": "端点或协议已变化，请重新输入 API Key", "models": []}
+        api_key = config.api_key
+    return await list_available_models(
+        base_url=base_url,
+        api_key=api_key,
+        protocol=protocol,
+    )
 
 
 @router.get("", response_model=list[TaskResponse])
@@ -434,11 +512,37 @@ async def update_task(task_id: str, req: UpdateTaskRequest, session: AsyncSessio
     if req.model_config_data is not None:
         patch = req.model_config_data.model_dump(exclude_unset=True)
         cfg = dict(task.model_config_json or {})
-        for key in ("base_url", "model"):
-            if key in patch and patch[key] is not None:
-                cfg[key] = str(patch[key]).strip()
-        if str(patch.get("api_key") or "").strip():
-            cfg["api_key"] = str(patch["api_key"]).strip()
+        current_runtime = resolve_llm_config(task)
+        current_identity = _llm_identity(
+            current_runtime.base_url, current_runtime.protocol
+        )
+        if patch.get("inherit_global") is True:
+            cfg = {k: v for k, v in cfg.items() if k == "prompt_version"}
+            cfg["inherit_global"] = True
+        elif patch.get("inherit_global") is False:
+            cfg.pop("providers", None)
+            cfg.pop("providers_json", None)
+            cfg["inherit_global"] = False
+        next_identity = _llm_identity(
+            patch.get("base_url")
+            if patch.get("base_url") is not None
+            else cfg.get("base_url") or current_runtime.base_url,
+            patch.get("protocol")
+            if patch.get("protocol") is not None
+            else cfg.get("protocol") or current_runtime.protocol,
+        )
+        supplied_key = str(patch.get("api_key") or "").strip()
+        has_new_key = bool(supplied_key and not is_masked_secret(supplied_key))
+        if current_identity != next_identity and not has_new_key:
+            cfg.pop("api_key", None)
+        for key in ("base_url", "model", "protocol"):
+            if not cfg.get("inherit_global") and key in patch and patch[key] is not None:
+                value = str(patch[key]).strip()
+                cfg[key] = normalize_llm_protocol(value) if key == "protocol" else value
+        if not cfg.get("inherit_global") and has_new_key:
+            cfg["api_key"] = supplied_key
+        if "prompt_version" in patch and patch.get("prompt_version") is not None:
+            cfg["prompt_version"] = str(patch["prompt_version"]).strip()
         task.model_config_json = cfg
 
     if req.engine_config is not None:

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,9 @@ class LLMConfig(BaseModel):
     api_key: str = os.environ.get("LLM_API_KEY", "")
     model: str = os.environ.get("LLM_MODEL", "deepseek-chat")
     temperature: float = float(os.environ.get("LLM_TEMPERATURE", "0.3"))
+    protocol: str = os.environ.get("LLM_PROTOCOL", "auto")
+    weight: int = int(os.environ.get("LLM_WEIGHT", "1"))
+    enabled: bool = True
 
 
 class WorkerConfig(BaseModel):

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -11,24 +11,55 @@ import os
 import json
 import logging
 import re
+import threading
 import time
-from typing import Any, Optional
+import uuid
+from typing import Any, Callable, Optional
 from types import SimpleNamespace
 
 import httpx
 from openai import OpenAI
 
 from app.config import LLMConfig, llm_config
+from app.llm.health import (
+    acquire_provider_slot,
+    mark_provider_failed,
+    mark_provider_behavior_failed,
+    mark_provider_behavior_ok,
+    mark_provider_ok,
+    provider_ref,
+    provider_retry_after_seconds,
+    snapshot as health_snapshot,
+)
 from app.llm.usage import record_usage
 
 logger = logging.getLogger("autohunter.llm")
 
-_SECRET_RE = re.compile(r"\b(sk-[A-Za-z0-9_-]{8,})\b")
+_SECRET_RE = re.compile(
+    r"(?:\bsk-[A-Za-z0-9_-]{8,}\b"
+    r"|\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}"
+    r"|(?:api[_-]?key|token|secret|password|passwd|pwd)"
+    r"\b[\"']?\s*[:=]\s*[\"']?[^\s'\"&]{6,})",
+    re.IGNORECASE,
+)
 
 # 单次 LLM 请求超时（秒）；DeepSeek 带工具调用通常 10-60s，120s 足够且能兜住挂起。
 _REQUEST_TIMEOUT = float(os.environ.get("LLM_REQUEST_TIMEOUT", "120"))
 # 失败重试次数（网络抖动/限流/5xx）；默认 4 次（含网络抖动场景多给几次机会）。
 _MAX_RETRIES = int(os.environ.get("LLM_MAX_RETRIES", "4"))
+_RR_LOCK = threading.Lock()
+# Smooth weighted round-robin current weights, keyed by pool/rank/provider.
+# The state is intentionally process-local; the production process runs one Uvicorn worker.
+_RR_STATE: dict[str, int] = {}
+
+
+def _api_root(base_url: str) -> str:
+    base = str(base_url or "").strip().rstrip("/")
+    lowered = base.lower()
+    for suffix in ("/chat/completions", "/messages"):
+        if lowered.endswith(suffix):
+            return base[: -len(suffix)].rstrip("/")
+    return base
 
 # 浏览器 UA（伪装成 Chrome，绕过 Cloudflare/WAF 对 SDK UA 的封禁）
 _BROWSER_UA = (
@@ -143,6 +174,7 @@ class LLMError(RuntimeError):
         status: int | None = None,
         code: str = "",
         detail: str = "",
+        retry_after: int = 0,
     ):
         super().__init__(message)
         self.kind = kind
@@ -150,6 +182,7 @@ class LLMError(RuntimeError):
         self.status = status
         self.code = code
         self.detail = detail
+        self.retry_after = max(0, int(retry_after or 0))
 
     def diagnostic(self) -> str:
         parts = [f"kind={self.kind}"]
@@ -160,6 +193,8 @@ class LLMError(RuntimeError):
         parts.append(f"message={super().__str__()}")
         if self.detail:
             parts.append(f"detail={self.detail}")
+        if self.retry_after:
+            parts.append(f"retry_after={self.retry_after}")
         return "；".join(parts)
 
     def __str__(self) -> str:
@@ -167,7 +202,7 @@ class LLMError(RuntimeError):
 
 
 def _sanitize_error_detail(text: str, limit: int = 1200) -> str:
-    text = _SECRET_RE.sub("sk-<masked>", text or "")
+    text = _SECRET_RE.sub("<masked>", text or "")
     text = " ".join(text.split())
     return text[:limit]
 
@@ -361,14 +396,31 @@ def _classify_error(e: Exception) -> LLMError:
             "quota", "LLM 额度不足或账户余额不足，请更换/充值模型 API Key 后重试。",
             e, status=status, code=str(code), detail=detail,
         )
-    if status == 401 or any(k in text for k in ("unauthorized", "invalid api key", "incorrect api key", "无效")):
+    if status == 401 or any(k in text for k in (
+        "unauthorized", "invalid api key", "incorrect api key",
+        "api key 无效", "apikey 无效", "密钥无效", "令牌无效",
+    )):
         return LLMError(
             "auth", "LLM API Key 无效或无权限，请检查任务配置或服务端 .env。",
+            e, status=status, code=str(code), detail=detail,
+        )
+    if status == 403 or any(k in text for k in (
+        "forbidden", "request blocked", "access denied", "content policy", "被拦截", "禁止访问",
+    )):
+        return LLMError(
+            "blocked", "LLM 请求被上游网关或安全策略拒绝，请切换端点或检查访问策略。",
             e, status=status, code=str(code), detail=detail,
         )
     if status == 429 or any(k in text for k in ("rate limit", "too many requests", "限流")):
         return LLMError(
             "rate_limit", "LLM 请求被限流，请稍后重试或降低并发。",
+            e, status=status, code=str(code), detail=detail,
+        )
+    if status in {400, 422} or any(k in text for k in (
+        "invalid_request", "bad request", "unprocessable entity", "参数有误", "参数错误",
+    )):
+        return LLMError(
+            "invalid_request", "LLM 请求参数不被当前端点接受，请切换端点或检查协议配置。",
             e, status=status, code=str(code), detail=detail,
         )
     if any(k in text for k in ("timeout", "timed out", "readtimeout", "connecttimeout", "超时")):
@@ -397,12 +449,160 @@ def _classify_error(e: Exception) -> LLMError:
     )
 
 
+def _should_try_next_provider(error: Exception) -> bool:
+    if not isinstance(error, LLMError):
+        return False
+    if error.kind in {
+        "quota", "auth", "blocked", "invalid_request",
+        "rate_limit", "timeout", "network", "upstream",
+    }:
+        return True
+    if error.kind != "unknown":
+        return False
+    try:
+        status = int(error.status or 0)
+    except (TypeError, ValueError):
+        status = 0
+    return status == 0 or status >= 400
+
+
+def _should_retry_current_provider(error: Exception) -> bool:
+    return isinstance(error, LLMError) and error.kind in {
+        "rate_limit", "timeout", "network", "upstream",
+    }
+
+
+def _provider_weight(provider: LLMConfig) -> int:
+    try:
+        weight = int(getattr(provider, "weight", 1) or 1)
+    except (TypeError, ValueError):
+        weight = 1
+    return max(1, min(weight, 100))
+
+
+def _provider_health_rank(provider: LLMConfig, health: dict[str, dict[str, Any]]) -> int:
+    state = health.get(provider_ref(
+        provider.base_url, provider.model, provider.api_key, provider.protocol
+    )) or {}
+    status = str(state.get("status") or "")
+    if status == "half_open":
+        return 0
+    if status == "failed":
+        return 1
+    if status == "cooldown":
+        return 2
+    return 0
+
+
 class LLMClient:
-    def __init__(self, config: Optional[LLMConfig] = None, usage_key: str | None = None):
-        self.config = config or llm_config
+    def __init__(
+        self,
+        config: Optional[LLMConfig] = None,
+        usage_key: str | None = None,
+        providers: Optional[list[LLMConfig]] = None,
+        pool_mode: bool | None = None,
+        on_provider_failure: Callable[[dict[str, Any]], None] | None = None,
+        on_provider_selected: Callable[[dict[str, Any]], None] | None = None,
+    ):
+        raw_providers = list(providers) if providers is not None else [config or llm_config]
+        self.providers = [
+            provider for provider in raw_providers
+            if provider and provider.api_key and getattr(provider, "enabled", True)
+        ]
         self.usage_key = usage_key
-        if not self.config.api_key:
-            raise RuntimeError("缺少 LLM_API_KEY，请在 .env 中配置")
+        # A one-entry pool has no failover candidate and must retain single-provider
+        # transport retries even when the configuration mode is named "pool".
+        self.pool_mode = len(self.providers) > 1 and (
+            pool_mode is None or bool(pool_mode)
+        )
+        self.on_provider_failure = on_provider_failure
+        self.on_provider_selected = on_provider_selected
+        self.selected_provider: LLMConfig | None = None
+        if not self.providers:
+            raise RuntimeError("缺少 LLM_API_KEY/LLM_PROVIDERS_JSON，请在 .env 或系统设置中配置")
+        self._auto_protocol_cache: dict[str, bool] = {}
+        self._insecure_provider_refs: set[str] = set()
+        self._global_insecure_tls = os.environ.get("LLM_INSECURE_TLS", "").strip() in ("1", "true", "True")
+        self._client_cache: dict[tuple[str, bool], OpenAI] = {}
+        self._sticky_provider_ref = ""
+        self._provider_slot_owner = uuid.uuid4().hex
+        self._activate_provider(self.providers[0])
+
+    def _provider_order(self) -> list[LLMConfig]:
+        if len(self.providers) <= 1:
+            return list(self.providers)
+        health = health_snapshot()
+        if self._sticky_provider_ref:
+            sticky_index = next((
+                index
+                for index, provider in enumerate(self.providers)
+                if provider_ref(
+                    provider.base_url, provider.model, provider.api_key, provider.protocol
+                )
+                == self._sticky_provider_ref
+                and _provider_health_rank(provider, health) == 0
+            ), None)
+            if sticky_index is not None:
+                remaining = sorted(
+                    (index for index in range(len(self.providers)) if index != sticky_index),
+                    key=lambda index: _provider_health_rank(self.providers[index], health),
+                )
+                return [self.providers[sticky_index], *(self.providers[index] for index in remaining)]
+        groups: dict[int, list[int]] = {0: [], 1: [], 2: []}
+        for index, provider in enumerate(self.providers):
+            groups[_provider_health_rank(provider, health)].append(index)
+
+        ordered: list[int] = []
+        for rank in (0, 1, 2):
+            for index in self._weighted_group_order(groups[rank], rank):
+                if index not in ordered:
+                    ordered.append(index)
+        return [self.providers[index] for index in ordered]
+
+    def _weighted_group_order(self, indices: list[int], rank: int) -> list[int]:
+        if not indices:
+            return []
+        positions = {index: position for position, index in enumerate(indices)}
+        refs = {
+            index: provider_ref(
+                self.providers[index].base_url,
+                self.providers[index].model,
+                self.providers[index].api_key,
+                self.providers[index].protocol,
+            )
+            for index in indices
+        }
+        weights = {index: _provider_weight(self.providers[index]) for index in indices}
+        pool_key = "|".join(
+            f"{refs[index]}:{weights[index]}"
+            for index in indices
+        )
+        total_weight = sum(weights.values())
+        state_prefix = f"{rank}:{pool_key}:"
+        with _RR_LOCK:
+            scores: dict[int, int] = {}
+            for index in indices:
+                key = f"{state_prefix}{positions[index]}:{refs[index]}"
+                score = _RR_STATE.get(key, 0) + weights[index]
+                _RR_STATE[key] = score
+                scores[index] = score
+
+            # Choose the highest accumulated score, then subtract the pool total.
+            # This is the standard Smooth WRR recurrence and avoids bursts such as
+            # A,A,A,B for a 3:1 pool while preserving the exact long-run ratio.
+            selected = max(indices, key=lambda index: (scores[index], -positions[index]))
+            selected_key = f"{state_prefix}{positions[selected]}:{refs[selected]}"
+            _RR_STATE[selected_key] -= total_weight
+            scores[selected] -= total_weight
+
+            remaining = sorted(
+                (index for index in indices if index != selected),
+                key=lambda index: (-scores[index], positions[index]),
+            )
+        return [selected, *remaining]
+
+    def _activate_provider(self, config: LLMConfig) -> None:
+        self.config = config
         # 协议自适应：先按显式配置/强特征确定；不确定时给个默认猜测(未锁定)，
         # 运行时若首个请求报“协议不匹配”特征错误，自动切另一种协议重试并沿用。
         self._messages_protocol, self._protocol_locked = self._detect_messages_protocol()
@@ -410,29 +610,48 @@ class LLMClient:
         self._is_https = self.config.base_url.lower().startswith("https")
         # TLS 自适应：默认走正规证书校验；只有当 base_url 是 https 且首次遇到
         # “证书校验失败”（多为自建中转/网关的自签证书）时，才自动降级为不校验并沿用。
-        # 也支持显式 LLM_INSECURE_TLS=1 一开始就不校验（兜底）。
-        self._insecure_tls = os.environ.get("LLM_INSECURE_TLS", "").strip() in ("1", "true", "True")
-        self.client = self._build_client(insecure=self._insecure_tls)
+        # 也支持显式 LLM_INSECURE_TLS=1 一开始就不校验（兜底）。降级状态按端点隔离。
+        ref = provider_ref(
+            self.config.base_url, self.config.model, self.config.api_key, self.config.protocol
+        )
+        self._insecure_tls = self._global_insecure_tls or ref in self._insecure_provider_refs
+        cache_key = (ref, self._insecure_tls)
+        if cache_key not in self._client_cache:
+            self._client_cache[cache_key] = self._build_client(insecure=self._insecure_tls)
+        self.client = self._client_cache[cache_key]
 
     def _detect_messages_protocol(self) -> tuple[bool, bool]:
         """判定协议，返回 (是否 Anthropic Messages, 是否已锁定)。
 
-        - 环境变量 LLM_PROTOCOL 显式指定 → 锁定（messages/anthropic → True，openai/chat → False）。
+        - 当前 provider 显式指定 → 锁定（anthropic_messages / openai_chat）。
         - base_url 强特征（openmodel.ai / 路径含 messages / anthropic）→ 锁定 messages。
         - base_url 强特征（路径含 chat/completions）→ 锁定 openai。
         - 都没命中 → 默认按 openai 猜测，但**不锁定**，交给运行时自适应纠正。
         """
-        explicit = os.environ.get("LLM_PROTOCOL", "").strip().lower()
-        if explicit in ("messages", "anthropic"):
+        explicit = str(getattr(self.config, "protocol", "auto") or "auto").strip().lower()
+        if explicit in ("messages", "anthropic", "anthropic_messages"):
             return True, True
-        if explicit in ("openai", "chat", "completions"):
+        if explicit in ("openai", "chat", "completions", "openai_chat"):
             return False, True
+        ref = provider_ref(
+            self.config.base_url, self.config.model, self.config.api_key, self.config.protocol
+        )
+        if ref in self._auto_protocol_cache:
+            return self._auto_protocol_cache[ref], False
         url = self.config.base_url.lower()
         if "openmodel.ai" in url or "/messages" in url or "anthropic" in url:
             return True, True
         if "/chat/completions" in url or "chat/completions" in url:
             return False, True
         return False, False  # 默认 openai，未锁定，运行时可自适应切换
+
+    def _remember_auto_protocol(self) -> None:
+        if self._protocol_locked:
+            return
+        ref = provider_ref(
+            self.config.base_url, self.config.model, self.config.api_key, self.config.protocol
+        )
+        self._auto_protocol_cache[ref] = self._messages_protocol
 
     def _maybe_switch_protocol(self, exc: Exception) -> bool:
         """协议自适应：首个请求报“协议不匹配”特征错误时，自动切另一种协议重试。
@@ -466,7 +685,7 @@ class LLMClient:
         # 关闭 SDK 内置重试，自己控制重试节奏与日志；设请求超时兜住挂起。
         # default_headers 换 UA + 抹 x-stainless-*，绕过中转/WAF 对 SDK UA 的 403 封禁。
         return OpenAI(
-            base_url=self.config.base_url, api_key=self.config.api_key,
+            base_url=_api_root(self.config.base_url), api_key=self.config.api_key,
             timeout=_REQUEST_TIMEOUT, max_retries=0,
             default_headers=_llm_default_headers(self.config.model, self.config.base_url),
             **({"http_client": http_client} if http_client else {}),
@@ -488,7 +707,14 @@ class LLMClient:
         )
         if any(m in text for m in tls_markers):
             self._insecure_tls = True
-            self.client = self._build_client(insecure=True)
+            ref = provider_ref(
+                self.config.base_url, self.config.model, self.config.api_key, self.config.protocol
+            )
+            self._insecure_provider_refs.add(ref)
+            cache_key = (ref, True)
+            if cache_key not in self._client_cache:
+                self._client_cache[cache_key] = self._build_client(insecure=True)
+            self.client = self._client_cache[cache_key]
             logger.warning("检测到 LLM 中转 TLS 证书校验失败，已自动降级为不校验证书重试（多为自建自签中转）")
             return True
         return False
@@ -501,10 +727,156 @@ class LLMClient:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
     ):
-        """单次对话调用，返回完整 message 对象（可能含 tool_calls）。
+        """调用一个健康端点，失败时按健康状态和权重切换备用端点。"""
+        last_exc: Exception | None = None
+        cooldown_delays: list[int] = []
+        order = self._provider_order()
+        for index, provider in enumerate(order):
+            self._activate_provider(provider)
+            can_try, slot_state = acquire_provider_slot(
+                provider.base_url,
+                provider.model,
+                provider.api_key,
+                provider.protocol,
+                owner=self._provider_slot_owner,
+            )
+            if not can_try:
+                cooldown_delays.append(
+                    provider_retry_after_seconds(
+                        provider.base_url, provider.model, provider.api_key, provider.protocol
+                    )
+                )
+                continue
+            self.selected_provider = provider
+            self._notify_provider_selected(provider, slot_state)
+            try:
+                message = self._chat_current_provider(
+                    messages, tools, tool_choice, temperature, max_tokens
+                )
+                self._remember_auto_protocol()
+                mark_provider_ok(
+                    provider.base_url, provider.model, provider.api_key, provider.protocol
+                )
+                self._sticky_provider_ref = provider_ref(
+                    provider.base_url, provider.model, provider.api_key, provider.protocol
+                )
+                return message
+            except Exception as exc:
+                error = exc if isinstance(exc, LLMError) else _classify_error(exc)
+                state = mark_provider_failed(
+                    provider.base_url,
+                    provider.model,
+                    str(error),
+                    provider.api_key,
+                    provider.protocol,
+                    kind=getattr(error, "kind", ""),
+                )
+                self._notify_provider_failure(error, state)
+                last_exc = error
+                if (
+                    not self.pool_mode
+                    and state.get("status") == "cooldown"
+                    and _should_retry_current_provider(error)
+                ):
+                    retry_after = provider_retry_after_seconds(
+                        provider.base_url,
+                        provider.model,
+                        provider.api_key,
+                        provider.protocol,
+                    )
+                    raise LLMError(
+                        "provider_cooldown",
+                        f"LLM 端点正在冷却，预计 {retry_after} 秒后重试。",
+                        retry_after=retry_after,
+                    )
+                if index + 1 < len(order) and _should_try_next_provider(error):
+                    logger.warning(
+                        "LLM provider failed; trying next provider %d/%d "
+                        "(kind=%s, slot=%s, model=%s, base=%s)",
+                        index + 2, len(order), getattr(error, "kind", "?"), slot_state,
+                        provider.model, provider.base_url,
+                    )
+                    continue
+                if self.pool_mode and _should_try_next_provider(error):
+                    break
+                raise error
 
-        带超时 + 指数退避重试；耗尽重试后抛出最后一次异常（调用方已有兜底）。
-        """
+        # A cooldown result means that no endpoint was actually called. If at
+        # least one endpoint was called, preserve its real error so quota/auth/
+        # request failures are not misreported as a generic pool cooldown.
+        if last_exc:
+            raise last_exc
+        if cooldown_delays:
+            retry_after = min(cooldown_delays)
+            raise LLMError(
+                "provider_cooldown",
+                f"LLM 端点池正在冷却，预计 {retry_after} 秒后重试。",
+                retry_after=retry_after,
+            )
+        raise RuntimeError("没有可用的 LLM 端点")
+
+    def _notify_provider_selected(self, provider: LLMConfig, slot_state: str) -> None:
+        if not self.on_provider_selected:
+            return
+        try:
+            self.on_provider_selected({
+                "base_url": provider.base_url,
+                "model": provider.model,
+                "protocol": provider.protocol,
+                "slot_state": slot_state,
+            })
+        except Exception:
+            logger.exception("LLM provider selection callback failed")
+
+    def _notify_provider_failure(self, error: Exception, state: dict[str, Any]) -> None:
+        if not self.on_provider_failure:
+            return
+        try:
+            self.on_provider_failure({
+                "base_url": self.config.base_url,
+                "model": self.config.model,
+                "kind": getattr(error, "kind", ""),
+                "status": getattr(error, "status", None),
+                "error": _sanitize_error_detail(str(error), 500),
+                "provider_status": state.get("status"),
+                "transition": state.get("transition"),
+                "consecutive_failures": state.get("consecutive_failures", 0),
+                "cooldown_seconds": state.get("cooldown_seconds", 0),
+                "cooldown_until": state.get("cooldown_until", ""),
+            })
+        except Exception:
+            logger.exception("LLM provider failure callback failed")
+
+    def report_current_provider_failure(self, reason: str, *, kind: str = "model_behavior") -> dict[str, Any]:
+        error = LLMError(kind, _sanitize_error_detail(reason, 500))
+        state = mark_provider_behavior_failed(
+            self.config.base_url,
+            self.config.model,
+            str(error),
+            self.config.api_key,
+            self.config.protocol,
+            kind=kind,
+        )
+        self._notify_provider_failure(error, state)
+        return state
+
+    def report_current_provider_success(self) -> None:
+        mark_provider_behavior_ok(
+            self.config.base_url,
+            self.config.model,
+            self.config.api_key,
+            self.config.protocol,
+        )
+
+    def _chat_current_provider(
+        self,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
+        tool_choice: str = "auto",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ):
+        """单次对话调用，返回完整 message 对象（可能含 tool_calls）。"""
         kwargs: dict[str, Any] = {
             "model": self.config.model,
             "messages": messages,
@@ -524,7 +896,10 @@ class LLMClient:
         active_tool_choice: Any = tool_choice
         tool_choice_fallback_used = False
         max_tokens_fallback_used = False
-        for attempt in range(_MAX_RETRIES + 1):
+        max_retries = 0 if self.pool_mode else _MAX_RETRIES
+        retry_count = 0
+        # TLS/协议/参数兼容降级各自最多触发一次，不占传输重试次数。
+        for _attempt in range(max_retries + 5):
             try:
                 if self._messages_protocol:
                     return self._messages_chat(
@@ -578,17 +953,25 @@ class LLMClient:
                     kwargs.pop("max_tokens", None)
                     max_tokens_fallback_used = True
                     continue
-                if attempt < _MAX_RETRIES:
+                if not _should_retry_current_provider(last_exc):
+                    logger.warning(
+                        "LLM chat failed without same-provider retry (kind=%s, model=%s)",
+                        kind, self.config.model,
+                    )
+                    break
+                if retry_count < max_retries:
                     logger.info("LLM chat retry %d/%d (kind=%s, model=%s)",
-                                attempt + 1, _MAX_RETRIES, kind, self.config.model)
-                    time.sleep(min(2 ** attempt, 8))  # 1s, 2s, 4s... 封顶 8s
+                                retry_count + 1, max_retries, kind, self.config.model)
+                    time.sleep(min(2 ** retry_count, 8))  # 1s, 2s, 4s... 封顶 8s
+                    retry_count += 1
                 else:
                     logger.warning("LLM chat giving up after %d retries (kind=%s, model=%s)",
-                                   _MAX_RETRIES, kind, self.config.model)
+                                   max_retries, kind, self.config.model)
+                    break
         raise last_exc  # type: ignore[misc]
 
     def _messages_url(self) -> str:
-        base = self.config.base_url.rstrip("/")
+        base = _api_root(self.config.base_url)
         if base.endswith("/v1"):
             return f"{base}/messages"
         return f"{base}/v1/messages"
@@ -703,7 +1086,9 @@ class LLMClient:
                 payload["tool_choice"] = choice
         headers = {
             "Authorization": f"Bearer {self.config.api_key}",
+            "x-api-key": self.config.api_key,
             "Content-Type": "application/json",
+            "Accept": "application/json",
             "anthropic-version": "2023-06-01",
             # 换 UA，绕过中转/2api WAF 对 SDK UA 的 403 封禁。
             "User-Agent": _resolve_user_agent(self.config.model, self.config.base_url),

--- a/app/llm/health.py
+++ b/app/llm/health.py
@@ -1,0 +1,413 @@
+"""LLM 端点运行时健康状态：失败计数、冷却与 half-open 探测。"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import hashlib
+import math
+import os
+import threading
+from typing import Any
+
+
+_HEALTH: dict[str, dict[str, Any]] = {}
+_LOCK = threading.Lock()
+_FAIL_THRESHOLD = max(1, int(os.environ.get("LLM_PROVIDER_FAIL_THRESHOLD", "5")))
+_BEHAVIOR_FAIL_THRESHOLD = max(1, int(os.environ.get("LLM_PROVIDER_BEHAVIOR_FAIL_THRESHOLD", "3")))
+_FAILED_RETRY_SECONDS = max(1, int(os.environ.get("LLM_PROVIDER_FAILED_RETRY_SECONDS", "60")))
+_TRANSPORT_PROBE_SECONDS = max(1, int(os.environ.get("LLM_PROVIDER_PROBE_SECONDS", "120")))
+_BEHAVIOR_PROBE_SECONDS = max(1, int(os.environ.get("LLM_PROVIDER_BEHAVIOR_PROBE_SECONDS", "900")))
+
+
+def _cooldown_steps() -> list[int]:
+    values: list[int] = []
+    for raw in os.environ.get("LLM_PROVIDER_COOLDOWN_SECONDS", "300,900,1800,3600").split(","):
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            continue
+        if value > 0:
+            values.append(value)
+    return values or [300]
+
+
+_COOLDOWN_STEPS = _cooldown_steps()
+
+
+def provider_ref(
+    base_url: str,
+    model: str,
+    api_key: str = "",
+    protocol: str = "auto",
+) -> str:
+    raw = "|".join([
+        str(base_url or "").strip().rstrip("/"),
+        str(model or "").strip(),
+        str(api_key or "").strip(),
+        str(protocol or "auto").strip().lower(),
+    ])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.isoformat()
+
+
+def _cooldown_seconds(count: int) -> int:
+    return _COOLDOWN_STEPS[min(max(0, count), len(_COOLDOWN_STEPS) - 1)]
+
+
+def _base_row(ref: str, base_url: str, model: str, protocol: str) -> dict[str, Any]:
+    return {
+        "ref": ref,
+        "base_url": str(base_url or "").strip().rstrip("/"),
+        "model": str(model or "").strip(),
+        "protocol": str(protocol or "auto").strip().lower(),
+    }
+
+
+def _transport_status(row: dict[str, Any]) -> str:
+    if "transport_status" in row:
+        return str(row.get("transport_status") or "ok")
+    if "behavior_status" in row:
+        return "ok"
+    return str(row.get("status") or "ok")
+
+
+def _refresh_status(row: dict[str, Any], now: datetime | None = None) -> str:
+    now_ts = (now or _now()).timestamp()
+    transport = _transport_status(row)
+    behavior = str(row.get("behavior_status") or "ok")
+    if transport == "cooldown" and float(row.get("cooldown_until_ts") or 0) > now_ts:
+        status = "cooldown"
+    elif behavior == "cooldown" and float(row.get("behavior_cooldown_until_ts") or 0) > now_ts:
+        status = "cooldown"
+    elif transport == "half_open" or behavior == "half_open":
+        status = "half_open"
+    elif transport == "failed" or behavior == "failed":
+        status = "failed"
+    else:
+        status = "ok"
+    row["status"] = status
+    return status
+
+
+def _refresh_expired_probes(row: dict[str, Any], now: datetime) -> None:
+    now_ts = now.timestamp()
+    transport = _transport_status(row)
+    if transport == "failed" and float(row.get("failed_retry_at_ts") or 0) <= now_ts:
+        row["transport_status"] = "half_open"
+        row["half_open_inflight"] = False
+    elif transport == "cooldown" and float(row.get("cooldown_until_ts") or 0) <= now_ts:
+        row["transport_status"] = "half_open"
+        row["half_open_inflight"] = False
+    elif (
+        transport == "half_open"
+        and row.get("half_open_inflight")
+        and float(row.get("half_open_until_ts") or 0) <= now_ts
+    ):
+        row["half_open_inflight"] = False
+        row["half_open_until_ts"] = 0
+
+    behavior = str(row.get("behavior_status") or "ok")
+    if behavior == "failed" and float(row.get("behavior_retry_at_ts") or 0) <= now_ts:
+        row["behavior_status"] = "half_open"
+        row["behavior_probe_owner"] = ""
+        row["behavior_probe_until_ts"] = 0
+    elif behavior == "cooldown" and float(row.get("behavior_cooldown_until_ts") or 0) <= now_ts:
+        row["behavior_status"] = "half_open"
+        row["behavior_probe_owner"] = ""
+        row["behavior_probe_until_ts"] = 0
+    elif behavior == "half_open" and float(row.get("behavior_probe_until_ts") or 0) <= now_ts:
+        row["behavior_probe_owner"] = ""
+        row["behavior_probe_until_ts"] = 0
+    _refresh_status(row, now)
+
+
+def acquire_provider_slot(
+    base_url: str,
+    model: str,
+    api_key: str = "",
+    protocol: str = "auto",
+    owner: str = "",
+) -> tuple[bool, str]:
+    """申请一次调用资格；冷却到期后仅放行一个 half-open 请求。"""
+    ref = provider_ref(base_url, model, api_key, protocol)
+    now = _now()
+    with _LOCK:
+        row = _HEALTH.get(ref)
+        if not row:
+            return True, "ready"
+        _refresh_expired_probes(row, now)
+        transport_status = _transport_status(row)
+        if transport_status == "failed":
+            return False, "failed"
+        if transport_status == "cooldown":
+            return False, "cooldown"
+        if transport_status == "half_open" and row.get("half_open_inflight"):
+            return False, "half_open_inflight"
+
+        behavior_status = str(row.get("behavior_status") or "ok")
+        if behavior_status == "cooldown":
+            return False, "behavior_cooldown"
+        if behavior_status == "failed":
+            return False, "behavior_failed"
+        if behavior_status == "half_open":
+            probe_owner = str(row.get("behavior_probe_owner") or "")
+            if probe_owner and probe_owner != owner:
+                return False, "behavior_half_open_inflight"
+            if not probe_owner:
+                row["behavior_probe_owner"] = owner or "anonymous"
+                row["behavior_probe_until_ts"] = now.timestamp() + _BEHAVIOR_PROBE_SECONDS
+            _refresh_status(row, now)
+
+        if transport_status == "half_open":
+            row["half_open_inflight"] = True
+            row["half_open_until_ts"] = now.timestamp() + _TRANSPORT_PROBE_SECONDS
+            row["last_seen"] = _iso(now)
+            _refresh_status(row, now)
+            return True, "half_open"
+        _refresh_status(row, now)
+        return True, "ready"
+
+
+def provider_retry_after_seconds(
+    base_url: str, model: str, api_key: str = "", protocol: str = "auto"
+) -> int:
+    ref = provider_ref(base_url, model, api_key, protocol)
+    now_ts = _now().timestamp()
+    with _LOCK:
+        row = _HEALTH.get(ref) or {}
+        delays: list[float] = []
+        if row.get("behavior_status") == "failed":
+            delays.append(float(row.get("behavior_retry_at_ts") or 0) - now_ts)
+        if row.get("behavior_status") == "cooldown":
+            delays.append(float(row.get("behavior_cooldown_until_ts") or 0) - now_ts)
+        if _transport_status(row) == "failed":
+            delays.append(float(row.get("failed_retry_at_ts") or 0) - now_ts)
+        if _transport_status(row) == "cooldown":
+            delays.append(float(row.get("cooldown_until_ts") or 0) - now_ts)
+        if row.get("half_open_inflight"):
+            delays.append(min(5.0, float(row.get("half_open_until_ts") or 0) - now_ts))
+        if row.get("behavior_probe_owner"):
+            delays.append(min(5.0, float(row.get("behavior_probe_until_ts") or 0) - now_ts))
+    positive = [delay for delay in delays if delay > 0]
+    return max(1, int(math.ceil(min(positive)))) if positive else 1
+
+
+def mark_provider_ok(
+    base_url: str, model: str, api_key: str = "", protocol: str = "auto"
+) -> dict[str, Any]:
+    ref = provider_ref(base_url, model, api_key, protocol)
+    now = _now()
+    with _LOCK:
+        row = _HEALTH.setdefault(ref, {})
+        row.update({
+            **_base_row(ref, base_url, model, protocol),
+            "transport_status": "ok",
+            "last_error": "",
+            "error_kind": "",
+            "last_seen": _iso(now),
+            "consecutive_failures": 0,
+            "cooldown_count": 0,
+            "cooldown_seconds": 0,
+            "cooldown_until": "",
+            "cooldown_until_ts": 0,
+            "failed_retry_at_ts": 0,
+            "half_open_inflight": False,
+            "half_open_until_ts": 0,
+        })
+        _refresh_status(row, now)
+        return dict(row)
+
+
+def mark_provider_behavior_failed(
+    base_url: str,
+    model: str,
+    error: str,
+    api_key: str = "",
+    protocol: str = "auto",
+    *,
+    kind: str = "model_behavior",
+) -> dict[str, Any]:
+    ref = provider_ref(base_url, model, api_key, protocol)
+    now = _now()
+    with _LOCK:
+        row = _HEALTH.setdefault(ref, {})
+        if (
+            row.get("behavior_status") == "cooldown"
+            and now.timestamp() < float(row.get("behavior_cooldown_until_ts") or 0)
+        ):
+            row.update({
+                **_base_row(ref, base_url, model, protocol),
+                "behavior_last_error": " ".join(str(error or "").split())[:500],
+                "behavior_error_kind": kind,
+                "last_seen": _iso(now),
+            })
+            return {**row, "transition": "behavior_cooldown_suppressed"}
+        strikes = int(row.get("behavior_strikes") or 0) + 1
+        status = "failed"
+        cooldown_seconds = 0
+        cooldown_until = ""
+        cooldown_until_ts = 0.0
+        transition = "behavior_failure_recorded"
+        retry_at_ts = now.timestamp() + _FAILED_RETRY_SECONDS
+        if strikes >= _BEHAVIOR_FAIL_THRESHOLD:
+            status = "cooldown"
+            cooldown_seconds = _cooldown_seconds(int(row.get("behavior_cooldown_count") or 0))
+            until = now + timedelta(seconds=cooldown_seconds)
+            cooldown_until = _iso(until)
+            cooldown_until_ts = until.timestamp()
+            row["behavior_cooldown_count"] = int(row.get("behavior_cooldown_count") or 0) + 1
+            transition = "behavior_cooldown_started"
+            retry_at_ts = 0
+        row.update({
+            **_base_row(ref, base_url, model, protocol),
+            "behavior_status": status,
+            "behavior_strikes": strikes,
+            "behavior_last_error": " ".join(str(error or "").split())[:500],
+            "behavior_error_kind": kind,
+            "behavior_cooldown_until": cooldown_until,
+            "behavior_cooldown_until_ts": cooldown_until_ts,
+            "behavior_retry_at_ts": retry_at_ts,
+            "behavior_probe_owner": "",
+            "behavior_probe_until_ts": 0,
+            "last_seen": _iso(now),
+        })
+        _refresh_status(row, now)
+        return {
+            **row,
+            "transition": transition,
+            "consecutive_failures": strikes,
+            "cooldown_seconds": cooldown_seconds,
+        }
+
+
+def mark_provider_behavior_ok(
+    base_url: str, model: str, api_key: str = "", protocol: str = "auto"
+) -> dict[str, Any]:
+    ref = provider_ref(base_url, model, api_key, protocol)
+    with _LOCK:
+        row = _HEALTH.setdefault(ref, {})
+        row.update({
+            **_base_row(ref, base_url, model, protocol),
+            "behavior_status": "ok",
+            "behavior_strikes": 0,
+            "behavior_last_error": "",
+            "behavior_error_kind": "",
+            "behavior_cooldown_until": "",
+            "behavior_cooldown_until_ts": 0,
+            "behavior_retry_at_ts": 0,
+            "behavior_cooldown_count": 0,
+            "behavior_probe_owner": "",
+            "behavior_probe_until_ts": 0,
+        })
+        _refresh_status(row)
+        return dict(row)
+
+
+def mark_provider_failed(
+    base_url: str,
+    model: str,
+    error: str,
+    api_key: str = "",
+    protocol: str = "auto",
+    *,
+    kind: str = "",
+) -> dict[str, Any]:
+    ref = provider_ref(base_url, model, api_key, protocol)
+    now = _now()
+    with _LOCK:
+        row = _HEALTH.get(ref)
+        if str(kind or "").strip().lower() == "invalid_request":
+            # A 400/422 describes this request, not endpoint availability. It
+            # may still trigger same-call failover, but must not suppress the
+            # endpoint for unrelated workers. If this was a half-open probe,
+            # release the lease without changing the prior health counters.
+            if row is None:
+                return {
+                    **_base_row(ref, base_url, model, protocol),
+                    "transport_status": "ok",
+                    "behavior_status": "ok",
+                    "status": "ok",
+                    "consecutive_failures": 0,
+                    "cooldown_seconds": 0,
+                    "transition": "request_rejected",
+                }
+            if _transport_status(row) == "half_open" and row.get("half_open_inflight"):
+                row["half_open_inflight"] = False
+                row["half_open_until_ts"] = 0
+            if str(row.get("behavior_status") or "") == "half_open":
+                row["behavior_probe_owner"] = ""
+                row["behavior_probe_until_ts"] = 0
+            _refresh_status(row, now)
+            return {**row, "transition": "request_rejected"}
+
+        row = _HEALTH.setdefault(ref, {})
+        previous_status = _transport_status(row)
+        if previous_status == "cooldown" and now.timestamp() < float(row.get("cooldown_until_ts") or 0):
+            row.update({
+                **_base_row(ref, base_url, model, protocol),
+                "transport_status": "cooldown",
+                "last_error": " ".join(str(error or "").split())[:500],
+                "error_kind": str(kind or ""),
+                "last_seen": _iso(now),
+                "half_open_inflight": False,
+                "half_open_until_ts": 0,
+            })
+            return {**row, "transition": "cooldown_suppressed"}
+
+        consecutive = int(row.get("consecutive_failures") or 0) + 1
+        cooldown_count = int(row.get("cooldown_count") or 0)
+        status = "failed"
+        cooldown_seconds = 0
+        cooldown_until = ""
+        cooldown_until_ts = 0.0
+        transition = "failure_recorded"
+        failed_retry_at_ts = now.timestamp() + _FAILED_RETRY_SECONDS
+        if consecutive >= _FAIL_THRESHOLD:
+            status = "cooldown"
+            cooldown_seconds = _cooldown_seconds(cooldown_count)
+            until = now + timedelta(seconds=cooldown_seconds)
+            cooldown_until = _iso(until)
+            cooldown_until_ts = until.timestamp()
+            cooldown_count += 1
+            transition = "cooldown_probe_failed" if previous_status == "half_open" else "cooldown_started"
+            failed_retry_at_ts = 0
+
+        if row.get("behavior_status") == "half_open":
+            row.update({
+                "behavior_status": "failed",
+                "behavior_retry_at_ts": now.timestamp() + _FAILED_RETRY_SECONDS,
+                "behavior_probe_owner": "",
+                "behavior_probe_until_ts": 0,
+            })
+
+        row.update({
+            **_base_row(ref, base_url, model, protocol),
+            "transport_status": status,
+            "last_error": " ".join(str(error or "").split())[:500],
+            "error_kind": str(kind or ""),
+            "last_seen": _iso(now),
+            "consecutive_failures": consecutive,
+            "cooldown_count": cooldown_count,
+            "cooldown_seconds": cooldown_seconds,
+            "cooldown_until": cooldown_until,
+            "cooldown_until_ts": cooldown_until_ts,
+            "failed_retry_at_ts": failed_retry_at_ts,
+            "half_open_inflight": False,
+            "half_open_until_ts": 0,
+        })
+        _refresh_status(row, now)
+        return {**row, "transition": transition}
+
+
+def snapshot() -> dict[str, dict[str, Any]]:
+    with _LOCK:
+        now = _now()
+        for row in _HEALTH.values():
+            _refresh_expired_probes(row, now)
+        return {ref: dict(row) for ref, row in _HEALTH.items()}

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -318,8 +318,12 @@ def _probe_target_liveness(url: str, host: str, timeout: float) -> dict:
     }
 
 
-def _llm_for_task(task: Task) -> LLMClient:
-    return llm_client_for_task(task)
+def _llm_for_task(task: Task, on_provider_failure=None, on_provider_selected=None) -> LLMClient:
+    return llm_client_for_task(
+        task,
+        on_provider_failure=on_provider_failure,
+        on_provider_selected=on_provider_selected,
+    )
 
 
 class TaskRunner:
@@ -353,6 +357,10 @@ class TaskRunner:
         self._queue_liveness_ok_until: dict[str, float] = {}
         # 5xx 等临时预筛失败不进终态 skipped，只做短冷却，稍后再探。
         self._queue_prefilter_retry_after: dict[str, float] = {}
+        # 端点池全部冷却时按 worker 返回的 retry-after 暂缓该目标，不消耗普通重试次数。
+        self._llm_provider_retry_after: dict[str, float] = {}
+        # 全池不可用是任务级条件；冷却期间不要让其它 queued 目标逐个启动再回队。
+        self._llm_pool_retry_after: float = 0
 
     def live_workers(self) -> list[dict]:
         return list(self._live.values())
@@ -392,6 +400,73 @@ class TaskRunner:
         # ts 统一用带 UTC 标识的 ISO 字符串（…+00:00），前端 new Date 才能正确转本地时区。
         await bus.publish(self.task_id, {"agent": agent, "kind": kind, "level": level,
                                          "message": message, "ts": _now_iso(), **payload})
+
+    @staticmethod
+    def _llm_payload(llm: LLMClient, model_role: str) -> dict:
+        config = getattr(llm, "selected_provider", None)
+        return {
+            "model_role": model_role,
+            "model": getattr(config, "model", "") or "",
+            "base_url": getattr(config, "base_url", "") or "",
+        }
+
+    def _provider_selected_callback(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        target_id: str,
+        model_role: str,
+    ):
+        def on_selected(info: dict) -> None:
+            def apply_selection() -> None:
+                state = self._live.get(target_id)
+                if not state:
+                    return
+                state["model_role"] = model_role
+                state["model"] = str(info.get("model") or "")
+                state["model_base_url"] = str(info.get("base_url") or "")
+
+            loop.call_soon_threadsafe(apply_selection)
+
+        return on_selected
+
+    def _provider_failure_callback(self, loop: asyncio.AbstractEventLoop, agent: str, **extra):
+        def on_failure(info: dict) -> None:
+            payload = {**(info or {}), **extra}
+            future = asyncio.run_coroutine_threadsafe(
+                self._record_provider_failure(agent, payload),
+                loop,
+            )
+            future.add_done_callback(_consume_task_exception)
+        return on_failure
+
+    async def _record_provider_failure(self, agent: str, payload: dict) -> None:
+        model = payload.get("model") or ""
+        base_url = payload.get("base_url") or ""
+        kind = payload.get("kind") or "failed"
+        consecutive = int(payload.get("consecutive_failures") or 0)
+        cooldown_seconds = int(payload.get("cooldown_seconds") or 0)
+        transition = payload.get("transition") or ""
+        if transition in {"cooldown_probe_failed", "behavior_cooldown_started"}:
+            message = (
+                f"LLM 端点进入冷却：{model} @ {base_url}"
+                f"（{kind}，连续失败 {consecutive} 次，冷却 {cooldown_seconds} 秒）"
+            )
+        else:
+            message = (
+                f"LLM 端点运行失败，正在尝试池内其它端点：{model} @ {base_url}"
+                f"（{kind}，连续失败 {consecutive} 次）"
+            )
+        event_payload = dict(payload)
+        event_payload["error_kind"] = event_payload.pop("kind", kind)
+        async with SessionLocal() as session:
+            await self._log(
+                session,
+                agent,
+                "llm_provider_failed",
+                message,
+                level="error",
+                **event_payload,
+            )
 
     async def recover(self, session: AsyncSession) -> None:
         """重启恢复：assigned/scanning → queued；不动已有 Finding/Review。"""
@@ -455,7 +530,17 @@ class TaskRunner:
                     **payload,
                 )
 
-            added = await collector.refill(session, task, LOW_WATERMARK, progress_cb=collector_progress)
+            added = await collector.refill(
+                session,
+                task,
+                LOW_WATERMARK,
+                progress_cb=collector_progress,
+                on_provider_failure=self._provider_failure_callback(
+                    asyncio.get_running_loop(),
+                    "collector",
+                    model_role="搜集模型",
+                ),
+            )
 
             # FOFA 账号连续无效达阈值 → 自动暂停任务，不再空转刷无效请求。
             fofa_fail = int((task.fofa_config or {}).get("fofa_auth_fail_count", 0))
@@ -553,9 +638,16 @@ class TaskRunner:
         # 多取一批是为了遇到同款系统正在跑/已冷却时，能跳到其它 cluster。
         loop = asyncio.get_running_loop()
         now = loop.time()
+        if self._llm_pool_retry_after > now:
+            return None
+        self._llm_pool_retry_after = 0
         if self._queue_prefilter_retry_after:
             self._queue_prefilter_retry_after = {
                 tid: until for tid, until in self._queue_prefilter_retry_after.items() if until > now
+            }
+        if self._llm_provider_retry_after:
+            self._llm_provider_retry_after = {
+                tid: until for tid, until in self._llm_provider_retry_after.items() if until > now
             }
         candidates = (await session.execute(
             select(Target).where(Target.task_id == self.task_id, Target.status == "queued")
@@ -582,6 +674,8 @@ class TaskRunner:
         eligible: list[Target] = []
         for target in candidates:
             if self._queue_prefilter_retry_after.get(target.id, 0) > now:
+                continue
+            if self._llm_provider_retry_after.get(target.id, 0) > now:
                 continue
             key = target_cluster.target_cluster_key(target.host or target.url, target.title, target.org)
             # 企业模式：目标多为用户指定的具体资产（pre-paycenter/test-gateway 等不同子系统），
@@ -1422,6 +1516,12 @@ class TaskRunner:
             st["last_activity_at"] = _now_iso()
             if "round" in data:
                 st["round"] = data["round"]
+            if data.get("model"):
+                st["model"] = data["model"]
+            if data.get("base_url"):
+                st["model_base_url"] = data["base_url"]
+            if data.get("model_role"):
+                st["model_role"] = data["model_role"]
             if kind == "tool_http":
                 st["action"] = f"HTTP {data.get('method','GET')} {data.get('url','')}"
             elif kind == "tool_shell":
@@ -1468,8 +1568,12 @@ class TaskRunner:
                 if cancel_event.is_set():
                     return
                 try:
+                    payload = {
+                        **(data or {}),
+                        **self._llm_payload(llm, "挖掘模型"),
+                    }
                     # finding_submitted 携带完整 finding：实时落库（不丢洞），并从看板推送里剥离大字段。
-                    finding_payload = data.pop("finding", None) if kind == "finding_submitted" else None
+                    finding_payload = payload.pop("finding", None) if kind == "finding_submitted" else None
                     if finding_payload:
                         ft = asyncio.create_task(
                             self._persist_single_finding(task_id, target_id, finding_payload)
@@ -1477,11 +1581,11 @@ class TaskRunner:
                         # 观测异常：finding 实时落库失败必须留痕，否则真洞可能静默丢失。
                         ft.add_done_callback(lambda f: _log_bg_task_exc(f, "persist_single_finding"))
                     if kind == "auth_status":
-                        at = asyncio.create_task(self._persist_auth_status(target_id, dict(data)))
+                        at = asyncio.create_task(self._persist_auth_status(target_id, dict(payload)))
                         at.add_done_callback(lambda f: _log_bg_task_exc(f, "persist_auth_status"))
-                    _update_live(kind, data)
+                    _update_live(kind, payload)
                     pt = asyncio.create_task(bus.publish(
-                        task_id, {"agent": "worker", "kind": kind, "target_id": target_id, **data}))
+                        task_id, {"agent": "worker", "kind": kind, "target_id": target_id, **payload}))
                     pt.add_done_callback(lambda f: _log_bg_task_exc(f, "bus.publish"))
                 except Exception:
                     logger.warning("TaskRunner[%s] emit dispatch failed target=%s kind=%s",
@@ -1570,7 +1674,16 @@ class TaskRunner:
                     self._live[target_id]["action"] = "🔁 定向深挖启动中…"
                 duplicate_history = await self._build_duplicate_history(session, task_id, tgt)
                 await session.commit()
-            llm = _llm_for_task(task_obj)
+            llm = _llm_for_task(
+                task_obj,
+                on_provider_failure=self._provider_failure_callback(
+                    loop, "worker", target_id=target_id
+                ),
+                on_provider_selected=self._provider_selected_callback(
+                    loop, target_id, "挖掘模型"
+                ),
+            )
+            self._live[target_id].update(self._llm_payload(llm, "挖掘模型"))
             prompt_version = resolve_worker_prompt_version(task_obj)
 
         worker_holder: dict[str, Worker] = {}
@@ -1713,6 +1826,9 @@ class TaskRunner:
             "started_at": live_snapshot.get("started_at"),
             "finished_at": _now_iso(),
             "duration_seconds": max(0.0, loop.time() - started_monotonic),
+            "model": live_snapshot.get("model") or "",
+            "base_url": live_snapshot.get("model_base_url") or live_snapshot.get("base_url") or "",
+            "model_role": live_snapshot.get("model_role") or "挖掘模型",
         })
         await self._persist_worker_result(task_id, target_id, final_result)
 
@@ -1958,6 +2074,12 @@ class TaskRunner:
             findings = result.get("findings", [])
             error_text = result.get("error") or ""
             summary_text = result.get("summary") or ""
+            failure_kind = str(result.get("failure_kind") or "").strip()
+            provider_cooldown = (
+                verdict == Verdict.error.value
+                and not findings
+                and result.get("failure_kind") == "provider_cooldown"
+            )
             auto_converged = (
                 verdict == Verdict.no_vuln.value
                 and not findings
@@ -1975,7 +2097,13 @@ class TaskRunner:
             transient_llm_error = (
                 verdict == Verdict.error.value
                 and not findings
-                and self._is_transient_worker_error(error_text)
+                and not provider_cooldown
+                and (
+                    failure_kind in {
+                        "model_behavior", "tool_argument",
+                    }
+                    or self._is_transient_worker_error(error_text)
+                )
             )
             # 自动深挖回火标记（worker 突破有线索时设置，用于日志）。
             auto_deepen_info = None
@@ -1989,6 +2117,24 @@ class TaskRunner:
                 if cnt > MAX_TRANSIENT_LLM_REQUEUE:
                     transient_llm_error = False
                     transient_exhausted = True
+
+            runtime = result.get("_runtime") if isinstance(result.get("_runtime"), dict) else {}
+            runtime_model = str(runtime.get("model") or "").strip()
+            runtime_base_url = str(runtime.get("base_url") or "").strip()
+            if runtime_model or runtime_base_url:
+                session.add(TaskEvent(
+                    task_id=task_id,
+                    agent="worker",
+                    kind="worker_model",
+                    level="info",
+                    message="",
+                    payload={
+                        "target_id": target_id,
+                        "model": runtime_model,
+                        "base_url": runtime_base_url,
+                        "model_role": str(runtime.get("model_role") or "挖掘模型"),
+                    },
+                ))
 
             # 落 Finding（含漏洞级去重；DB 唯一索引兜底，逐条 savepoint 容错并发重复）
             for f in findings:
@@ -2096,6 +2242,21 @@ class TaskRunner:
                 tgt.last_error = error_text[:500]
                 tgt.dead_reason = ""
                 await self._stop_task_for_quota(session, error_text, target_id=target_id)
+            elif provider_cooldown:
+                retry_after = max(1, int(result.get("retry_after_seconds") or 0))
+                self._llm_provider_retry_after[target_id] = (
+                    asyncio.get_running_loop().time() + retry_after
+                )
+                self._llm_pool_retry_after = max(
+                    self._llm_pool_retry_after,
+                    asyncio.get_running_loop().time() + retry_after,
+                )
+                tgt.verdict = ""
+                tgt.status = "queued"
+                tgt.assigned_worker = ""
+                tgt.heartbeat_at = None
+                tgt.last_error = error_text[:500]
+                tgt.dead_reason = ""
             elif transient_llm_error:
                 tgt.verdict = ""
                 tgt.status = "queued"
@@ -2106,6 +2267,8 @@ class TaskRunner:
             else:
                 tgt.verdict = verdict
             if quota_llm_error:
+                pass
+            elif provider_cooldown:
                 pass
             elif transient_llm_error:
                 pass
@@ -2200,6 +2363,8 @@ class TaskRunner:
             # 目标已离开「持续临时错误」状态（成功/无果/置dead），清理回队计数避免泄漏累积。
             if not transient_llm_error:
                 self._transient_llm_requeue.pop(target_id, None)
+            if not provider_cooldown:
+                self._llm_provider_retry_after.pop(target_id, None)
             await session.commit()
             if auto_deepen_info:
                 host, dc, lead = auto_deepen_info
@@ -2210,6 +2375,12 @@ class TaskRunner:
                 await self._log(session, "orchestrator", "quota_stop",
                                 f"LLM/API 额度不足，任务已自动停止: {error_text[:120]}",
                                 level="error", target_id=target_id, verdict="quota_stop", findings=0)
+            elif provider_cooldown:
+                retry_after = max(1, int(result.get("retry_after_seconds") or 0))
+                await self._log(session, "worker", "target_requeued",
+                                f"目标 {tgt.host} 因模型端点池冷却回队，约 {retry_after} 秒后重试: "
+                                f"{error_text[:120]}",
+                                level="warn", target_id=target_id, verdict="retry", findings=0)
             elif transient_llm_error:
                 await self._log(session, "worker", "target_requeued",
                                 f"目标 {tgt.host} 因临时 LLM 错误回队列(第 "
@@ -2330,7 +2501,12 @@ class TaskRunner:
                 kill_chain=f.kill_chain or [], self_check=f.self_check or {},
                 owner=f.owner or "",
             )
-            llm = _llm_for_task(task_obj)
+            llm = _llm_for_task(
+                task_obj,
+                on_provider_failure=self._provider_failure_callback(
+                    loop, "reviewer", finding_id=finding_id
+                ),
+            )
 
         def emit(kind: str, data: dict):
             asyncio.run_coroutine_threadsafe(
@@ -2490,7 +2666,12 @@ class TaskRunner:
                                 level="warn", finding_id=finding_id)
             return
 
-        llm = _llm_for_task(await self._get_task(task_id))
+        llm = _llm_for_task(
+            await self._get_task(task_id),
+            on_provider_failure=self._provider_failure_callback(
+                loop, "killsweep", finding_id=finding_id
+            ),
+        )
         cancel_event = threading.Event()
         self._killsweep_cancel_events[finding_id] = cancel_event
 
@@ -2685,7 +2866,12 @@ class TaskRunner:
                 "kill_chain": f.kill_chain, "severity": orig_severity,
             }
 
-        llm = _llm_for_task(await self._get_task(task_id))
+        llm = _llm_for_task(
+            await self._get_task(task_id),
+            on_provider_failure=self._provider_failure_callback(
+                loop, "escalation", finding_id=finding_id
+            ),
+        )
         cancel_event = threading.Event()
         self._escalation_cancel_events[finding_id] = cancel_event
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -73,6 +73,8 @@ class WorkerResult(BaseModel):
     summary: str = Field("", description="worker 对本次挖掘的总结")
     rounds: int = 0
     error: Optional[str] = None
+    failure_kind: str = Field("", description="结构化失败类型，供编排层决定是否回队")
+    retry_after_seconds: int = Field(0, ge=0, description="建议等待秒数；0 表示无需延迟")
     deepen_lead: str = Field("", description="突破入口但未打穿时的定向深挖线索，触发自动回火再派一轮")
     reported_intel: list[dict] = Field(default_factory=list, description="worker 主动上报的可复用情报，编排层落全局情报库")
     reported_coverage: list[dict] = Field(default_factory=list, description="单站协作覆盖记录，编排层写事件流供后续 worker 复用")

--- a/app/settings_service.py
+++ b/app/settings_service.py
@@ -1,8 +1,11 @@
 """全局系统配置：DB 持久化 + 内存缓存 + 与 env / 任务级合并解析。"""
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,14 +15,155 @@ from app.agents.prompts import normalize_worker_prompt_version
 from app.db.models import SystemSettings, Task, to_cst_iso
 from app.db.session import SessionLocal
 from app.engines import get_engine, list_engines, get_default_engine
+from app.llm.health import provider_ref, snapshot as llm_health_snapshot
 
 SETTINGS_ID = "global"
+LLM_MODES = {"single", "pool"}
+LLM_PROTOCOLS = {"auto", "openai_chat", "anthropic_messages"}
 
 _cache: dict[str, Any] = {"llm": {}, "fofa": {}, "engines": {}, "defaults": {}}
 
 
 # 统一脱敏占位：不再泄露密钥首尾字符，避免降低离线爆破成本。
 _MASK_PLACEHOLDER = "••••••••"
+
+
+def normalize_llm_mode(value: Any) -> str:
+    mode = str(value or "single").strip().lower()
+    return mode if mode in LLM_MODES else "single"
+
+
+def normalize_llm_protocol(value: Any) -> str:
+    protocol = str(value or "auto").strip().lower()
+    aliases = {
+        "detect": "auto",
+        "openai": "openai_chat",
+        "chat": "openai_chat",
+        "completions": "openai_chat",
+        "messages": "anthropic_messages",
+        "anthropic": "anthropic_messages",
+    }
+    protocol = aliases.get(protocol, protocol)
+    return protocol if protocol in LLM_PROTOCOLS else "auto"
+
+
+def _normalize_llm_base_url(value: Any) -> str:
+    raw = str(value or "").strip().rstrip("/")
+    if not raw:
+        return ""
+    parts = urlsplit(raw)
+    if not parts.scheme or not parts.netloc:
+        return raw
+    return urlunsplit((
+        parts.scheme.lower(),
+        parts.netloc.lower(),
+        parts.path.rstrip("/"),
+        parts.query,
+        parts.fragment,
+    ))
+
+
+def _llm_identity(base_url: Any, protocol: Any) -> tuple[str, str]:
+    return _normalize_llm_base_url(base_url), normalize_llm_protocol(protocol)
+
+
+def _json_list(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [dict(item) for item in value if isinstance(item, dict)]
+    raw = str(value or "").strip()
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    return [dict(item) for item in data if isinstance(item, dict)] if isinstance(data, list) else []
+
+
+def secret_ref(value: str) -> str:
+    secret = str(value or "").strip()
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:16] if secret else ""
+
+
+def _provider_enabled(value: Any) -> bool:
+    return not (
+        value is False
+        or str(value).strip().lower() in {"0", "false", "no", "off", "disabled"}
+    )
+
+
+def _clean_llm_providers(items: Any) -> list[dict[str, Any]]:
+    providers: list[dict[str, Any]] = []
+    for index, item in enumerate(_json_list(items)):
+        base_url = str(item.get("base_url") or item.get("base") or "").strip()
+        api_key = str(item.get("api_key") or item.get("key") or "").strip()
+        model = str(item.get("model") or "").strip()
+        if not (base_url and api_key and model):
+            continue
+        try:
+            temperature = float(item.get("temperature", 0.3))
+        except (TypeError, ValueError):
+            temperature = 0.3
+        try:
+            weight = int(item.get("weight", 1))
+        except (TypeError, ValueError):
+            weight = 1
+        providers.append({
+            "name": str(item.get("name") or f"llm-{index + 1}").strip(),
+            "base_url": base_url,
+            "api_key": api_key,
+            "model": model,
+            "protocol": normalize_llm_protocol(item.get("protocol")),
+            "temperature": max(0.0, min(temperature, 2.0)),
+            "weight": max(1, min(weight, 100)),
+            "enabled": _provider_enabled(item.get("enabled", True)),
+        })
+    return providers
+
+
+def _preserve_provider_keys(
+    items: Any,
+    old_providers: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in _json_list(items):
+        row = dict(item)
+        supplied = str(row.get("api_key") or row.get("key") or "").strip()
+        if not supplied or is_masked_secret(supplied):
+            ref = str(row.get("key_ref") or row.get("api_key_ref") or "").strip()
+            identity = _llm_identity(row.get("base_url"), row.get("protocol"))
+            name = str(row.get("name") or "").strip()
+            old_key = ""
+            for old in old_providers:
+                candidate = str(old.get("api_key") or "").strip()
+                if not candidate or _llm_identity(old.get("base_url"), old.get("protocol")) != identity:
+                    continue
+                if ref and secret_ref(candidate) != ref:
+                    continue
+                if not ref and str(old.get("name") or "").strip() != name:
+                    continue
+                old_key = candidate
+                break
+            if old_key:
+                row["api_key"] = old_key
+        out.append(row)
+    return out
+
+
+def _public_llm_provider(item: dict[str, Any]) -> dict[str, Any]:
+    api_key = str(item.get("api_key") or "").strip()
+    health_ref = provider_ref(
+        item.get("base_url", ""), item.get("model", ""), api_key, item.get("protocol", "auto")
+    )
+    return {
+        **{key: value for key, value in item.items() if key != "api_key"},
+        "api_key": "",
+        "api_key_set": bool(api_key),
+        "api_key_masked": mask_secret(api_key),
+        "key_ref": secret_ref(api_key),
+        "health_ref": health_ref,
+        "health": llm_health_snapshot().get(health_ref, {}),
+    }
 
 
 def mask_secret(value: str) -> str:
@@ -38,11 +182,16 @@ def is_masked_secret(value: str) -> bool:
 
 
 def _env_llm() -> dict[str, Any]:
+    providers = _clean_llm_providers(os.environ.get("LLM_PROVIDERS_JSON", ""))
+    configured_mode = os.environ.get("LLM_PROVIDER_MODE", "").strip()
     return {
+        "mode": normalize_llm_mode(configured_mode or ("pool" if providers else "single")),
         "base_url": os.environ.get("LLM_BASE_URL", "https://api.deepseek.com/v1"),
         "api_key": os.environ.get("LLM_API_KEY", ""),
         "model": os.environ.get("LLM_MODEL", "deepseek-chat"),
         "temperature": float(os.environ.get("LLM_TEMPERATURE", "0.3")),
+        "protocol": normalize_llm_protocol(os.environ.get("LLM_PROTOCOL", "auto")),
+        "providers": providers,
     }
 
 
@@ -100,22 +249,114 @@ def _merge_section(stored: dict, env: dict) -> dict[str, Any]:
 
 def effective_settings() -> dict[str, Any]:
     """合并 env + DB 缓存的有效配置（含明文密钥，仅服务端内部使用）。"""
+    stored_llm = _cache.get("llm") or {}
+    env_llm = _env_llm()
+    llm = _merge_section(stored_llm, env_llm)
+    if (
+        not str(stored_llm.get("api_key") or "").strip()
+        and any(str(stored_llm.get(key) or "").strip() for key in ("base_url", "protocol"))
+        and _llm_identity(llm.get("base_url"), llm.get("protocol"))
+        != _llm_identity(env_llm.get("base_url"), env_llm.get("protocol"))
+    ):
+        llm["api_key"] = ""
+    if not str(stored_llm.get("mode") or os.environ.get("LLM_PROVIDER_MODE") or "").strip():
+        llm["mode"] = "pool" if _clean_llm_providers(llm.get("providers")) else "single"
+    else:
+        llm["mode"] = normalize_llm_mode(llm.get("mode"))
+    llm["protocol"] = normalize_llm_protocol(llm.get("protocol"))
     return {
-        "llm": _merge_section(_cache.get("llm"), _env_llm()),
+        "llm": llm,
         "fofa": _merge_section(_cache.get("fofa"), _env_fofa()),
         "engines": _merge_section(_cache.get("engines"), _env_engines()),
         "defaults": _merge_section(_cache.get("defaults"), _env_defaults()),
     }
 
 
-def resolve_llm_config(task: Task | None = None) -> LLMConfig:
+def _llm_config_from_provider(item: dict[str, Any], default_temperature: float) -> LLMConfig:
+    return LLMConfig(
+        base_url=str(item.get("base_url") or "").strip(),
+        api_key=str(item.get("api_key") or "").strip(),
+        model=str(item.get("model") or "").strip(),
+        temperature=float(item.get("temperature", default_temperature)),
+        protocol=normalize_llm_protocol(item.get("protocol")),
+        weight=max(1, min(int(item.get("weight") or 1), 100)),
+        enabled=_provider_enabled(item.get("enabled", True)),
+    )
+
+
+def resolve_llm_providers(task: Task | None = None) -> list[LLMConfig]:
     eff = effective_settings()["llm"]
     mc = (task.model_config_json or {}) if task else {}
-    return LLMConfig(
-        base_url=mc.get("base_url") or eff["base_url"],
-        api_key=mc.get("api_key") or eff["api_key"],
-        model=mc.get("model") or eff["model"],
+    inherit_setting = mc.get("inherit_global")
+    inherit_global = inherit_setting is True
+    if inherit_global:
+        mc = {"inherit_global": True, "prompt_version": mc.get("prompt_version")}
+    task_providers = _clean_llm_providers(
+        mc.get("providers") or mc.get("providers_json") or []
+    )
+    if task_providers:
+        return [
+            _llm_config_from_provider(item, float(eff["temperature"]))
+            for item in task_providers
+            if item.get("enabled", True)
+        ]
+
+    task_has_single_override = any(
+        str(mc.get(key) or "").strip()
+        for key in ("base_url", "api_key", "model", "protocol")
+    )
+    implicit_global = inherit_setting is None and not task_has_single_override
+    if (inherit_global or implicit_global) and normalize_llm_mode(eff.get("mode")) == "pool":
+        providers = _clean_llm_providers(eff.get("providers") or [])
+        return [
+            _llm_config_from_provider(item, float(eff["temperature"]))
+            for item in providers
+            if item.get("enabled", True)
+        ]
+
+    base_url = mc.get("base_url") or eff["base_url"]
+    model = mc.get("model") or eff["model"]
+    protocol = normalize_llm_protocol(mc.get("protocol") or eff.get("protocol"))
+    api_key = str(mc.get("api_key") or "").strip()
+    if not api_key:
+        api_key = resolve_llm_key_for_identity(base_url, model, protocol)
+    config = LLMConfig(
+        base_url=base_url,
+        api_key=api_key,
+        model=model,
         temperature=float(mc.get("temperature") or eff["temperature"]),
+        protocol=protocol,
+        weight=1,
+        enabled=True,
+    )
+    return [config] if config.api_key else []
+
+
+def resolve_llm_runtime_mode(task: Task | None = None) -> str:
+    if task is None:
+        return normalize_llm_mode(effective_settings()["llm"].get("mode"))
+    mc = dict(task.model_config_json or {})
+    if mc.get("inherit_global") is False or mc.get("providers") or mc.get("providers_json"):
+        return "pool" if mc.get("providers") or mc.get("providers_json") else "single"
+    if mc.get("inherit_global") is True or not any(
+        str(mc.get(key) or "").strip()
+        for key in ("base_url", "api_key", "model", "protocol")
+    ):
+        return normalize_llm_mode(effective_settings()["llm"].get("mode"))
+    return "single"
+
+
+def resolve_llm_config(task: Task | None = None) -> LLMConfig:
+    providers = resolve_llm_providers(task)
+    if providers:
+        return providers[0]
+    eff = effective_settings()["llm"]
+    return LLMConfig(
+        base_url=eff["base_url"],
+        api_key="",
+        model=eff["model"],
+        temperature=float(eff["temperature"]),
+        protocol=normalize_llm_protocol(eff.get("protocol")),
     )
 
 
@@ -223,6 +464,15 @@ def public_settings_view() -> dict[str, Any]:
     fofa = eff["fofa"]
     engines = eff.get("engines", {})
     defaults = eff["defaults"]
+    llm_providers = _clean_llm_providers(llm.get("providers") or [])
+    llm_mode = normalize_llm_mode(llm.get("mode"))
+    single_key = resolve_llm_key_for_identity(
+        llm.get("base_url", ""), llm.get("model", ""), llm.get("protocol", "auto")
+    )
+    single_health_ref = provider_ref(
+        llm.get("base_url", ""), llm.get("model", ""), single_key, llm.get("protocol", "auto")
+    )
+    llm_health = llm_health_snapshot()
 
     # 构建引擎列表视图
     # FOFA 引擎需额外合并 fofa section 的 key/base_url（旧版兼容）
@@ -246,11 +496,18 @@ def public_settings_view() -> dict[str, Any]:
 
     return {
         "llm": {
+            "mode": llm_mode,
             "base_url": llm["base_url"],
             "model": llm["model"],
             "temperature": llm["temperature"],
-            "api_key": mask_secret(llm["api_key"]),
-            "api_key_set": bool(llm["api_key"]),
+            "protocol": normalize_llm_protocol(llm.get("protocol")),
+            "api_key": mask_secret(single_key),
+            "api_key_set": bool(single_key),
+            "key_ref": secret_ref(single_key),
+            "health_ref": single_health_ref,
+            "health": llm_health.get(single_health_ref, {}),
+            "provider_count": len(llm_providers),
+            "providers": [_public_llm_provider(item) for item in llm_providers],
         },
         "fofa": {
             "base_url": fofa.get("base_url") or "https://fofa.info",
@@ -303,10 +560,37 @@ async def update_settings(session: AsyncSession, payload: dict[str, Any]) -> dic
 
     if "llm" in payload and payload["llm"]:
         llm = dict(row.llm or {})
-        for k, v in payload["llm"].items():
+        current_llm = effective_settings()["llm"]
+        llm_update = dict(payload["llm"])
+        old_llm_providers = _clean_llm_providers(current_llm.get("providers") or [])
+        supplied_key = str(llm_update.get("api_key") or "").strip()
+        has_new_key = bool(supplied_key and not is_masked_secret(supplied_key))
+        next_identity = _llm_identity(
+            llm_update.get("base_url") or current_llm.get("base_url"),
+            llm_update.get("protocol") or current_llm.get("protocol"),
+        )
+        current_identity = _llm_identity(
+            current_llm.get("base_url"), current_llm.get("protocol")
+        )
+        if next_identity != current_identity and not has_new_key:
+            llm.pop("api_key", None)
+        if has_new_key:
+            llm.setdefault("base_url", current_llm.get("base_url", ""))
+            llm.setdefault("protocol", normalize_llm_protocol(current_llm.get("protocol")))
+        for k, v in llm_update.items():
             if k == "api_key":
                 if not str(v or "").strip() or is_masked_secret(v):
                     continue
+            if k == "providers":
+                preserved = _preserve_provider_keys(v or [], old_llm_providers)
+                llm["providers"] = _clean_llm_providers(preserved)
+                continue
+            if k == "mode":
+                llm["mode"] = normalize_llm_mode(v)
+                continue
+            if k == "protocol":
+                llm["protocol"] = normalize_llm_protocol(v)
+                continue
             if v is not None:
                 llm[k] = v
         row.llm = llm
@@ -361,33 +645,126 @@ async def update_settings(session: AsyncSession, payload: dict[str, Any]) -> dic
     return public_settings_view()
 
 
-def llm_client_for_task(task: Task | None = None):
+def llm_client_for_task(
+    task: Task | None = None,
+    on_provider_failure=None,
+    on_provider_selected=None,
+):
     """返回 LLMClient；无 key 时抛 RuntimeError（与旧行为一致）。"""
     from app.llm.client import LLMClient
 
-    return LLMClient(resolve_llm_config(task), usage_key=task.id if task else None)
+    return LLMClient(
+        providers=resolve_llm_providers(task),
+        pool_mode=resolve_llm_runtime_mode(task) == "pool",
+        usage_key=task.id if task else None,
+        on_provider_failure=on_provider_failure,
+        on_provider_selected=on_provider_selected,
+    )
 
 
-def llm_client_for_task_optional(task: Task | None = None):
+def llm_client_for_task_optional(
+    task: Task | None = None,
+    on_provider_failure=None,
+    on_provider_selected=None,
+):
     """有 key 则返回 LLMClient，否则 None（collector 降级）。"""
     from app.llm.client import LLMClient
 
-    cfg = resolve_llm_config(task)
-    if not cfg.api_key:
+    providers = resolve_llm_providers(task)
+    if not providers:
         return None
     try:
-        return LLMClient(cfg, usage_key=task.id if task else None)
+        return LLMClient(
+            providers=providers,
+            pool_mode=resolve_llm_runtime_mode(task) == "pool",
+            usage_key=task.id if task else None,
+            on_provider_failure=on_provider_failure,
+            on_provider_selected=on_provider_selected,
+        )
     except Exception:
         return None
 
 
-async def list_available_models(base_url: str | None = None, api_key: str | None = None) -> dict[str, Any]:
+def _llm_key_candidates() -> list[tuple[str, str, str, str]]:
+    llm = effective_settings()["llm"]
+    env_llm = _env_llm()
+    rows = [{
+        "base_url": llm.get("base_url", ""),
+        "api_key": llm.get("api_key", ""),
+        "model": llm.get("model", ""),
+        "protocol": llm.get("protocol", "auto"),
+    }, *_clean_llm_providers(llm.get("providers") or []), {
+        "base_url": env_llm.get("base_url", ""),
+        "api_key": env_llm.get("api_key", ""),
+        "model": env_llm.get("model", ""),
+        "protocol": env_llm.get("protocol", "auto"),
+    }, *_clean_llm_providers(env_llm.get("providers") or [])]
+    return [
+        (
+            str(row.get("base_url") or ""),
+            str(row.get("model") or ""),
+            normalize_llm_protocol(row.get("protocol")),
+            str(row.get("api_key") or "").strip(),
+        )
+        for row in rows
+        if str(row.get("api_key") or "").strip()
+    ]
+
+
+def resolve_llm_key_for_identity(
+    base_url: str | None,
+    model: str | None = None,
+    protocol: str | None = None,
+) -> str:
+    identity = _llm_identity(base_url, protocol)
+    if not all(identity):
+        return ""
+    for candidate_base, _candidate_model, candidate_protocol, key in _llm_key_candidates():
+        if _llm_identity(candidate_base, candidate_protocol) == identity:
+            return key
+    return ""
+
+
+def resolve_llm_key_ref(
+    key_ref: str | None,
+    base_url: str | None = None,
+    model: str | None = None,
+    protocol: str | None = None,
+) -> str:
+    ref = str(key_ref or "").strip()
+    identity = _llm_identity(base_url, protocol)
+    if not ref or not all(identity):
+        return ""
+    for candidate_base, _candidate_model, candidate_protocol, key in _llm_key_candidates():
+        if (
+            _llm_identity(candidate_base, candidate_protocol) == identity
+            and secret_ref(key) == ref
+        ):
+            return key
+    return ""
+
+
+async def list_available_models(
+    base_url: str | None = None,
+    api_key: str | None = None,
+    protocol: str | None = None,
+    key_ref: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
     """拉取模型商可用模型列表（OpenAI 兼容 GET /models）。"""
     import httpx
 
     eff = effective_settings()["llm"]
-    base = (base_url or eff["base_url"] or "").strip().rstrip("/")
-    key = (api_key or eff["api_key"] or "").strip()
+    resolved = resolve_llm_providers()
+    fallback = resolved[0] if resolved else resolve_llm_config()
+    base = (base_url or fallback.base_url or eff["base_url"] or "").strip().rstrip("/")
+    resolved_protocol = normalize_llm_protocol(protocol or fallback.protocol or eff.get("protocol"))
+    resolved_model = str(model or fallback.model or eff.get("model") or "").strip()
+    key = str(api_key or "").strip()
+    if not key or is_masked_secret(key):
+        key = resolve_llm_key_ref(
+            key_ref, base, resolved_model, resolved_protocol
+        ) or resolve_llm_key_for_identity(base, resolved_model, resolved_protocol)
     if not base:
         return {"ok": False, "error": "未配置模型 base_url", "models": []}
     if not key:
@@ -400,6 +777,11 @@ async def list_available_models(base_url: str | None = None, api_key: str | None
     except SsrfBlocked as e:
         return {"ok": False, "error": f"base_url 不被允许：{e}", "models": []}
     headers = {"Authorization": f"Bearer {key}"}
+    if resolved_protocol == "anthropic_messages":
+        headers.update({
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+        })
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             resp = await client.get(url, headers=headers)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -242,8 +242,15 @@ export const api = {
   userReview: (id, data) => req("PATCH", `/api/results/${id}`, data),
   deepen: (id, directive) => req("POST", `/api/results/${id}/deepen`, { directive }),
   getSettings: () => req("GET", "/api/settings"),
+  providerHealth: () => req("GET", "/api/settings/provider-health"),
   updateSettings: (data) => req("PUT", "/api/settings", data),
-  listModels: (base_url, api_key) => req("POST", "/api/settings/models", { base_url, api_key }),
+  listModels: (base_url, api_key, extra = {}) => req(
+    "POST",
+    "/api/settings/models",
+    typeof base_url === "object" ? base_url : { base_url, api_key, ...extra }
+  ),
+  taskModels: (id, data) => req("POST", `/api/tasks/${id}/models`, data),
+  testLLM: (data) => req("POST", "/api/settings/test-llm", data),
   // 全局情报库
   intelStats: () => req("GET", "/api/intel/stats"),
   intelList: (kind, confidence, q, limit) =>

--- a/frontend/src/components/TaskEditModal.vue
+++ b/frontend/src/components/TaskEditModal.vue
@@ -17,7 +17,12 @@ async function loadModels() {
   modelsLoading.value = true;
   modelsError.value = "";
   try {
-    const res = await api.listModels(form.base_url || undefined, form.api_key || undefined);
+    const res = await api.taskModels(props.task.id, {
+      base_url: form.base_url || undefined,
+      api_key: form.api_key || undefined,
+      key_ref: form.key_ref || undefined,
+      protocol: form.protocol,
+    });
     if (res?.ok && res.models?.length) {
       models.value = res.models;
       // 当前模型不在列表里 → 默认进入手输模式，避免选错
@@ -46,9 +51,12 @@ const form = reactive({
   intent_mode: "",
   manual_targets: "",
   src_rules: "",
+  inherit_model_global: true,
   base_url: "",
   api_key: "",
+  key_ref: "",
   model: "",
+  protocol: "auto",
   prompt_version: "legacy",
   fofa_key: "",
   fofa_base_url: "",
@@ -61,6 +69,7 @@ const authBindings = ref([{ target: "*", raw: "", username: "", password: "", co
 const original = reactive({
   base_url: "",
   model: "",
+  protocol: "auto",
   prompt_version: "legacy",
   intent_mode: "",
   fofa_base_url: "",
@@ -89,6 +98,13 @@ function addBinding() {
 function removeBinding(i) {
   authBindings.value.splice(i, 1);
   if (!authBindings.value.length) authBindings.value.push(emptyBinding());
+}
+
+function invalidateModelKey() {
+  form.key_ref = "";
+  models.value = [];
+  modelsError.value = "";
+  useCustomModel.value = true;
 }
 function exportAuthBindings() {
   return authBindings.value
@@ -137,7 +153,10 @@ function fill(task) {
   form.src_rules = task.src_rules || "";
   form.base_url = modelCfg.base_url || "";
   form.api_key = "";
+  form.key_ref = modelCfg.key_ref || "";
   form.model = modelCfg.model || "";
+  form.protocol = modelCfg.protocol || "auto";
+  form.inherit_model_global = modelCfg.inherit_global !== false;
   form.prompt_version = modelCfg.prompt_version || "legacy";
   form.fofa_key = "";
   form.fofa_base_url = fofaCfg.base_url || "";
@@ -148,6 +167,7 @@ function fill(task) {
   loadAuthBindings(task);
   original.base_url = form.base_url;
   original.model = form.model;
+  original.protocol = form.protocol;
   original.prompt_version = form.prompt_version;
   original.intent_mode = form.intent_mode;
   original.fofa_base_url = form.fofa_base_url;
@@ -168,11 +188,13 @@ watch(() => props.open, (open) => {
 });
 
 async function save() {
-  const modelConfig = {};
-  if (form.base_url !== original.base_url) modelConfig.base_url = form.base_url;
-  if (form.model !== original.model) modelConfig.model = form.model;
+  if (!form.inherit_model_global && !form.api_key.trim() && !form.key_ref) return;
+  const modelConfig = { inherit_global: form.inherit_model_global };
+  if (!form.inherit_model_global) modelConfig.base_url = form.base_url;
+  if (!form.inherit_model_global) modelConfig.model = form.model;
+  if (!form.inherit_model_global) modelConfig.protocol = form.protocol;
   if (form.prompt_version !== original.prompt_version) modelConfig.prompt_version = form.prompt_version;
-  if (form.api_key.trim()) modelConfig.api_key = form.api_key.trim();
+  if (!form.inherit_model_global && form.api_key.trim()) modelConfig.api_key = form.api_key.trim();
 
   const maxPages = parseInt(form.max_pages) || 20;
   const pageSize = parseInt(form.page_size) || 100;
@@ -305,22 +327,27 @@ async function save() {
 
       <details open>
         <summary>高级：模型 / FOFA</summary>
+        <label class="check-line">
+          <input v-model="form.inherit_model_global" type="checkbox" />
+          跟随系统模型方案
+        </label>
         <div class="settings-grid">
-          <label>模型 base_url <input v-model="form.base_url" placeholder="https://api.deepseek.com/v1" /></label>
+          <label>模型 base_url <input v-model="form.base_url" :disabled="form.inherit_model_global" :required="!form.inherit_model_global" placeholder="https://api.deepseek.com/v1" @input="invalidateModelKey" /></label>
           <label class="model-field">
             模型名
             <div class="model-picker">
-              <select v-if="models.length && !useCustomModel" v-model="form.model">
+              <select v-if="models.length && !useCustomModel" v-model="form.model" :disabled="form.inherit_model_global">
                 <option v-for="m in models" :key="m" :value="m">{{ m }}</option>
               </select>
-              <input v-else v-model="form.model" placeholder="deepseek-chat" />
-              <button type="button" class="ghost-btn" :disabled="modelsLoading" @click="loadModels" title="改了 base_url/api_key 后可重新拉取">
+              <input v-else v-model="form.model" :disabled="form.inherit_model_global" :required="!form.inherit_model_global" placeholder="deepseek-chat" />
+              <button type="button" class="ghost-btn" :disabled="modelsLoading || form.inherit_model_global" @click="loadModels" title="改了 base_url/api_key 后可重新拉取">
                 {{ modelsLoading ? "拉取中…" : "刷新" }}
               </button>
               <button
                 v-if="models.length"
                 type="button"
                 class="ghost-btn"
+                :disabled="form.inherit_model_global"
                 @click="useCustomModel = !useCustomModel"
               >
                 {{ useCustomModel ? "选列表" : "手动输入" }}
@@ -329,6 +356,13 @@ async function save() {
             <small v-if="modelsError" class="model-hint">{{ modelsError }}</small>
             <small v-else-if="models.length" class="model-hint">已获取 {{ models.length }} 个可用模型</small>
           </label>
+          <label>模型协议
+            <select v-model="form.protocol" :disabled="form.inherit_model_global" @change="invalidateModelKey">
+              <option value="auto">自动识别</option>
+              <option value="openai_chat">OpenAI Chat Completions</option>
+              <option value="anthropic_messages">Anthropic Messages</option>
+            </select>
+          </label>
           <label>Worker 提示词
             <select v-model="form.prompt_version">
               <option value="current">current（当前省 token 版）</option>
@@ -336,7 +370,7 @@ async function save() {
               <option value="modern">modern（当前完整版）</option>
             </select>
           </label>
-          <label>模型 api_key <input v-model="form.api_key" type="password" placeholder="留空保留原值" /></label>
+          <label>模型 api_key <input v-model="form.api_key" :disabled="form.inherit_model_global" :required="!form.inherit_model_global && !form.key_ref" type="password" :placeholder="form.key_ref ? '已配置，留空保留原值' : 'sk-...'" /></label>
           <label v-if="!isSiteMode">FOFA key <input v-model="form.fofa_key" type="password" placeholder="留空保留原值" /></label>
           <label v-if="!isSiteMode">FOFA API 端点 <input v-model="form.fofa_base_url" placeholder="https://fofa.info" /></label>
           <label v-if="!isSiteMode">FOFA 最大页数 <input v-model="form.max_pages" type="number" min="1" max="200" /></label>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1053,6 +1053,290 @@ main {
   margin-top: 6px;
 }
 .auth-grid .span2 { grid-column: 1 / -1; }
+.llm-mode-switch {
+  clear: both;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: min(320px, 100%);
+  margin-bottom: 16px;
+  padding: 3px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.llm-mode-switch button {
+  min-height: 34px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+}
+.llm-mode-switch button:hover {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+.llm-mode-switch button.active {
+  background: var(--surface);
+  color: var(--ink);
+  box-shadow: var(--shadow);
+}
+.llm-config-pane {
+  padding-top: 2px;
+}
+.llm-pool-pane {
+  display: grid;
+  gap: 12px;
+}
+.llm-pool-toolbar,
+.provider-detail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.llm-pool-toolbar > div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.llm-pool-toolbar b {
+  color: var(--ink);
+  font-size: 13px;
+}
+.llm-pool-toolbar span {
+  color: var(--faint);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+}
+.provider-empty {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 58px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.provider-selector {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.provider-selector-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  gap: 2px 8px;
+  min-height: 64px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  text-align: left;
+  background: var(--bg);
+}
+.provider-selector-row:hover {
+  background: var(--surface);
+}
+.provider-selector-row.active {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
+  background: color-mix(in oklch, var(--accent-bg) 35%, var(--surface));
+}
+.provider-selector-row.disabled {
+  opacity: .58;
+  border-style: dashed;
+}
+.provider-selector-row b,
+.provider-selector-row small,
+.provider-selector-row em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.provider-selector-row b {
+  grid-column: 2;
+  color: var(--ink);
+  font-size: 12.5px;
+}
+.provider-selector-row small {
+  grid-column: 2;
+  color: var(--muted);
+  font-size: 11px;
+}
+.provider-selector-row em {
+  grid-column: 3;
+  grid-row: 1;
+  color: var(--faint);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  font-style: normal;
+}
+.provider-selector-row i {
+  grid-column: 3;
+  grid-row: 2;
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+}
+.provider-dot {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  align-self: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--faint);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--faint) 14%, transparent);
+}
+.provider-dot.ok { background: var(--ok); box-shadow: 0 0 0 3px var(--ok-bg); }
+.provider-dot.failed { background: var(--danger); box-shadow: 0 0 0 3px var(--danger-bg); }
+.provider-dot.cooldown,
+.provider-dot.half-open { background: var(--warn); box-shadow: 0 0 0 3px var(--warn-bg); }
+.provider-detail {
+  display: grid;
+  gap: 12px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-soft);
+}
+.provider-detail-head > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.provider-detail-head span {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+}
+.provider-health {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  color: var(--muted);
+  background: var(--surface-2);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+.provider-health.ok { color: var(--ok); border-color: color-mix(in oklch, var(--ok) 35%, transparent); background: var(--ok-bg); }
+.provider-health.failed { color: var(--danger); border-color: color-mix(in oklch, var(--danger) 35%, transparent); background: var(--danger-bg); }
+.provider-health.cooldown,
+.provider-health.half-open { color: var(--warn); border-color: color-mix(in oklch, var(--warn) 35%, transparent); background: var(--warn-bg); }
+.provider-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.provider-head-actions > button {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  font-size: 16px;
+}
+.provider-head-actions .danger {
+  color: var(--danger);
+  border-color: color-mix(in oklch, var(--danger) 34%, var(--border));
+}
+.provider-enabled {
+  display: inline-flex !important;
+  grid-template-columns: none !important;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--ink-2) !important;
+  cursor: pointer;
+}
+.provider-enabled input {
+  width: auto;
+  margin: 0;
+  accent-color: var(--accent);
+}
+.provider-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 1fr) minmax(90px, .55fr);
+  gap: 11px;
+  align-items: end;
+}
+.provider-fields .wide {
+  grid-column: 1 / -1;
+}
+.model-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.model-picker input {
+  flex: 1;
+  min-width: 0;
+}
+.model-picker button {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.model-hint {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.provider-test,
+.settings-test {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+.settings-test-result {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 10px 11px;
+  border: 1px solid color-mix(in oklch, var(--warn) 42%, var(--border));
+  border-radius: 8px;
+  background: var(--warn-bg);
+}
+.settings-test-result.ok {
+  border-color: color-mix(in oklch, var(--ok) 42%, var(--border));
+  background: var(--ok-bg);
+}
+.settings-test-result b,
+.settings-test-result strong {
+  color: var(--ink);
+  font-size: 12px;
+}
+.settings-test-result p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+.settings-test-result ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.settings-test-result li {
+  display: grid;
+  gap: 2px;
+}
+.settings-test-result li.ok strong { color: var(--ok); }
+.settings-test-result li:not(.ok) strong { color: var(--danger); }
+.settings-test-result small {
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
 .settings-updated {
   display: block;
   margin-top: 6px;
@@ -1476,6 +1760,15 @@ main {
   margin: 8px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   background: var(--surface); border: 1px solid var(--border-soft); padding: 7px 9px; border-radius: var(--radius-sm);
 }
+.wc-model {
+  display: flex; gap: 6px; align-items: center; min-width: 0;
+  margin: -2px 0 8px; color: var(--faint); font-size: 11.5px;
+}
+.wc-model b {
+  max-width: 42%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--ink); font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+.wc-model small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wc-foot { display: flex; align-items: center; gap: 10px; }
 .wc-find { font-size: 11.5px; color: var(--faint); flex: none; }
 .wc-find.hit { color: var(--ok); font-weight: 600; }
@@ -2000,6 +2293,37 @@ main {
   .settings-grid {
     grid-template-columns: 1fr;
     gap: 12px;
+  }
+  .llm-mode-switch {
+    width: 100%;
+    margin-bottom: 12px;
+  }
+  .llm-pool-toolbar,
+  .provider-detail-head {
+    align-items: stretch;
+  }
+  .provider-selector,
+  .provider-fields {
+    grid-template-columns: 1fr;
+  }
+  .provider-fields .wide {
+    grid-column: auto;
+  }
+  .provider-detail-head {
+    display: grid;
+  }
+  .provider-head-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+  .provider-head-actions > button {
+    min-height: 38px;
+  }
+  .provider-enabled {
+    min-height: 38px;
+  }
+  .model-picker {
+    align-items: stretch;
   }
   .settings-actions {
     display: grid;

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -259,7 +259,7 @@ const IMPORTANT_KINDS = new Set([
   "reproduce_start", "reproduce_done",
   "killsweep_start", "killsweep_done", "killsweep_error", "killsweep_dedup",
   "killsweep_invalid", "killsweep_cancelled",
-  "llm_error", "quota_stop", "reclaim", "recover", "workers_cancelled",
+  "llm_error", "llm_provider_failed", "quota_stop", "reclaim", "recover", "workers_cancelled",
   "tool_exception",
   "auth_status",
 ]);
@@ -317,6 +317,7 @@ function fmtEvent(ev) {
     case "killsweep_dedup": return `通杀分析去重：${d.product || ""}`;
     case "killsweep_invalid": return `通杀记录已标记无效：${d.product || ""}`;
     case "llm_error": return `⚠ LLM 调用失败: ${d.error || ""}`;
+    case "llm_provider_failed": return `LLM 端点失败: ${d.model || ""} @ ${d.base_url || ""} (${d.error_kind || "failed"})`;
     case "tool_exception": return `工具异常: ${d.tool || ""} ${(d.error || "").slice(0, 80)}`;
     case "auth_status": {
       const kinds = (d.kinds || []).join(",") || "-";
@@ -764,6 +765,15 @@ const runState = computed(() => {
 const modelName = computed(() =>
   task.value?.model_config_data?.model || task.value?.llm_usage?.model || "未配置模型"
 );
+function compactBaseUrl(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  try { return new URL(raw).host; }
+  catch { return raw.replace(/^https?:\/\//, "").split("/")[0]; }
+}
+function workerModelTitle(worker) {
+  return [worker?.model_role || "挖掘模型", worker?.model, worker?.model_base_url].filter(Boolean).join(" · ");
+}
 const tokenUsage = computed(() => task.value?.llm_usage || {});
 const cacheHitRate = computed(() => {
   const u = tokenUsage.value || {};
@@ -1096,6 +1106,11 @@ function parseEventTs(ts) {
             </span>
           </div>
           <div class="wc-action">{{ w.action }}</div>
+          <div v-if="w.model || w.model_base_url" class="wc-model" :title="workerModelTitle(w)">
+            <span>{{ w.model_role || "挖掘模型" }}</span>
+            <b>{{ w.model || "未知模型" }}</b>
+            <small v-if="w.model_base_url">@ {{ compactBaseUrl(w.model_base_url) }}</small>
+          </div>
           <div class="wc-foot">
             <span class="wc-find" :class="{ hit: w.findings > 0 }">
               {{ w.findings > 0 ? `🎯 ${w.findings} 个漏洞` : "侦察中…" }}

--- a/frontend/src/views/CreateView.vue
+++ b/frontend/src/views/CreateView.vue
@@ -15,7 +15,8 @@ const form = reactive({
   intent_mode: "",
   manual_targets: "",
   src_rules: "",
-  base_url: "", api_key: "", model: "", prompt_version: "legacy",
+  inherit_model_global: true,
+  base_url: "", api_key: "", key_ref: "", model: "", protocol: "auto", prompt_version: "legacy",
   fofa_key: "", fofa_base_url: "", max_pages: 20, concurrency: 3,
   skip_site_recon: false,
   skip_recon_touched: false,   // 用户是否手动调过这个开关（调过就不再自动跟随凭据）
@@ -25,6 +26,9 @@ const authBindings = ref([{ target: "*", raw: "", username: "", password: "", co
 const inherited = reactive({
   base_url: "",
   model: "",
+  protocol: "auto",
+  llm_provider_count: 0,
+  llm_mode: "single",
   prompt_version: "legacy",
   fofa_base_url: "",
   max_pages: 20,
@@ -58,6 +62,10 @@ function removeBinding(i) {
   authBindings.value.splice(i, 1);
   if (!authBindings.value.length) authBindings.value.push(emptyBinding());
 }
+
+function invalidateModelKey() {
+  form.key_ref = "";
+}
 function exportAuthBindings() {
   return authBindings.value
     .map((b) => ({
@@ -88,10 +96,12 @@ watch([() => form.fofa_query, isSiteMode, authBindings], () => {
 });
 
 async function submit() {
-  const modelConfig = {};
-  if (form.api_key.trim()) modelConfig.api_key = form.api_key.trim();
-  if (form.base_url && form.base_url !== inherited.base_url) modelConfig.base_url = form.base_url;
-  if (form.model && form.model !== inherited.model) modelConfig.model = form.model;
+  if (!form.inherit_model_global && !form.api_key.trim() && !form.key_ref) return;
+  const modelConfig = { inherit_global: form.inherit_model_global };
+  if (!form.inherit_model_global && form.api_key.trim()) modelConfig.api_key = form.api_key.trim();
+  if (!form.inherit_model_global && form.base_url) modelConfig.base_url = form.base_url;
+  if (!form.inherit_model_global && form.model) modelConfig.model = form.model;
+  if (!form.inherit_model_global) modelConfig.protocol = form.protocol;
   if (form.prompt_version !== inherited.prompt_version) modelConfig.prompt_version = form.prompt_version;
 
   const maxPages = parseInt(form.max_pages) || 20;
@@ -125,6 +135,8 @@ onMounted(async () => {
     const s = await api.getSettings();
     if (!form.base_url) form.base_url = s.llm?.base_url || "";
     if (!form.model) form.model = s.llm?.model || "";
+    form.protocol = s.llm?.protocol || form.protocol;
+    form.key_ref = s.llm?.key_ref || "";
     form.prompt_version = s.defaults?.worker_prompt_version || form.prompt_version;
     form.max_pages = s.fofa?.max_pages ?? form.max_pages;
     if (!form.intent_mode) form.intent_mode = s.fofa?.default_intent_mode || "";
@@ -132,6 +144,9 @@ onMounted(async () => {
     form.concurrency = s.defaults?.concurrency ?? form.concurrency;
     inherited.base_url = form.base_url;
     inherited.model = form.model;
+    inherited.protocol = form.protocol;
+    inherited.llm_provider_count = s.llm?.provider_count || 0;
+    inherited.llm_mode = s.llm?.mode || "single";
     inherited.prompt_version = form.prompt_version;
     inherited.fofa_base_url = form.fofa_base_url;
     inherited.max_pages = Number(form.max_pages);
@@ -248,9 +263,24 @@ onMounted(async () => {
       </p>
       <details :open="adv">
         <summary @click="adv = !adv">高级：模型 / FOFA / 并发（留空用服务端默认）</summary>
-        <label>模型 base_url <input v-model="form.base_url" placeholder="https://api.deepseek.com/v1" /></label>
-        <label>模型 api_key <input v-model="form.api_key" type="password" /></label>
-        <label>模型名 <input v-model="form.model" placeholder="deepseek-chat" /></label>
+        <p class="field-hint">
+          当前系统方案：{{ inherited.llm_mode === "pool" ? inherited.llm_provider_count + " 个模型端点" : "单模型" }}。
+          跟随后，系统配置变更会在任务下一轮调用时生效。
+        </p>
+        <label class="check-line">
+          <input v-model="form.inherit_model_global" type="checkbox" />
+          跟随系统模型方案
+        </label>
+        <label>模型 base_url <input v-model="form.base_url" :disabled="form.inherit_model_global" :required="!form.inherit_model_global" placeholder="https://api.deepseek.com/v1" @input="invalidateModelKey" /></label>
+        <label>模型 api_key <input v-model="form.api_key" :disabled="form.inherit_model_global" :required="!form.inherit_model_global && !form.key_ref" type="password" :placeholder="form.key_ref ? '已配置，留空复用' : 'sk-...'" /></label>
+        <label>模型名 <input v-model="form.model" :disabled="form.inherit_model_global" :required="!form.inherit_model_global" placeholder="deepseek-chat" /></label>
+        <label>模型协议
+          <select v-model="form.protocol" :disabled="form.inherit_model_global" @change="invalidateModelKey">
+            <option value="auto">自动识别</option>
+            <option value="openai_chat">OpenAI Chat Completions</option>
+            <option value="anthropic_messages">Anthropic Messages</option>
+          </select>
+        </label>
         <label>Worker 提示词
           <select v-model="form.prompt_version">
             <option value="current">current（当前省 token 版）</option>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,11 +1,18 @@
 <script setup>
-import { reactive, ref, onMounted } from "vue";
+import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
 import { api } from "../api.js";
 
 const loading = ref(true);
 const saving = ref(false);
+const testingLlm = ref(false);
 const toastMsg = ref("");
 const meta = ref({ updated_at: null });
+const llmMode = ref("single");
+const llmTest = ref(null);
+const singleModels = ref([]);
+const singleModelsLoading = ref(false);
+const singleModelsError = ref("");
+let healthPoll = null;
 
 // ---- 一键更新 ----
 const updateState = reactive({
@@ -76,9 +83,13 @@ function pollHealth() {
 const form = reactive({
   base_url: "",
   api_key: "",
+  key_ref: "",
   model: "",
+  protocol: "openai_chat",
   temperature: 0.3,
   api_key_set: false,
+  llm_provider_count: 0,
+  llm_providers: [],
   fofa_key: "",
   fofa_key_set: false,
   fofa_base_url: "",
@@ -95,6 +106,305 @@ function toast(m) {
   setTimeout(() => (toastMsg.value = ""), 2600);
 }
 
+function newLlmProvider() {
+  return {
+    name: `llm-${form.llm_providers.length + 1}`,
+    base_url: form.base_url || "https://api.deepseek.com/v1",
+    api_key: "",
+    api_key_set: false,
+    api_key_masked: "",
+    key_ref: "",
+    health_ref: "",
+    model: form.model || "deepseek-chat",
+    protocol: form.protocol || "openai_chat",
+    temperature: Number(form.temperature ?? 0.3),
+    weight: 1,
+    enabled: true,
+    testing: false,
+    models: [],
+    modelsLoading: false,
+    modelsError: "",
+    health: {},
+  };
+}
+
+const selectedLlmProvider = ref(0);
+const selectedLlm = computed(() => form.llm_providers[selectedLlmProvider.value] || null);
+
+function normalizeLlmProtocol(protocol) {
+  return ["auto", "openai_chat", "anthropic_messages"].includes(protocol) ? protocol : "auto";
+}
+
+function loadLlmProviders(items = []) {
+  form.llm_providers = items.map((provider, idx) => ({
+    name: provider.name || `llm-${idx + 1}`,
+    base_url: provider.base_url || "",
+    api_key: "",
+    api_key_set: !!provider.api_key_set,
+    api_key_masked: provider.api_key_masked || "",
+    key_ref: provider.key_ref || "",
+    health_ref: provider.health_ref || "",
+    model: provider.model || "",
+    protocol: normalizeLlmProtocol(provider.protocol),
+    temperature: provider.temperature ?? form.temperature ?? 0.3,
+    weight: provider.weight ?? 1,
+    enabled: provider.enabled !== false,
+    testing: false,
+    models: [],
+    modelsLoading: false,
+    modelsError: "",
+    health: provider.health || {},
+  }));
+  selectedLlmProvider.value = form.llm_providers.length ? 0 : -1;
+}
+
+function providerHealthClass(provider) {
+  const status = provider.health?.status || "";
+  if (["ok", "failed", "cooldown", "half_open"].includes(status)) {
+    return status.replace("_", "-");
+  }
+  return "unknown";
+}
+
+function providerHealthText(provider) {
+  const status = provider.health?.status || "";
+  if (status === "ok") return "健康";
+  if (status === "failed") return "失效";
+  if (status === "cooldown") return "冷却中";
+  if (status === "half_open") return "探测中";
+  return "未检测";
+}
+
+function providerHealthTitle(provider) {
+  const health = provider.health || {};
+  if (!health.last_seen) return "暂无运行时健康记录";
+  const parts = [health.last_seen];
+  if (health.consecutive_failures) parts.push(`连续失败 ${health.consecutive_failures} 次`);
+  if (health.cooldown_until) parts.push(`冷却到 ${health.cooldown_until}`);
+  if (health.last_error) parts.push(health.last_error);
+  return parts.join("；");
+}
+
+function addLlmProvider() {
+  form.llm_providers.push(newLlmProvider());
+  selectedLlmProvider.value = form.llm_providers.length - 1;
+  llmTest.value = null;
+}
+
+function removeLlmProvider(idx) {
+  form.llm_providers.splice(idx, 1);
+  if (!form.llm_providers.length) selectedLlmProvider.value = -1;
+  else selectedLlmProvider.value = Math.min(idx, form.llm_providers.length - 1);
+  llmTest.value = null;
+}
+
+function moveLlmProvider(idx, delta) {
+  const next = idx + delta;
+  if (next < 0 || next >= form.llm_providers.length) return;
+  const [provider] = form.llm_providers.splice(idx, 1);
+  form.llm_providers.splice(next, 0, provider);
+  if (selectedLlmProvider.value === idx) selectedLlmProvider.value = next;
+  else if (selectedLlmProvider.value === next) selectedLlmProvider.value = idx;
+}
+
+function buildLlmProvider(provider) {
+  return {
+    name: String(provider.name || "").trim(),
+    base_url: String(provider.base_url || "").trim(),
+    api_key: String(provider.api_key || "").trim(),
+    key_ref: provider.key_ref || "",
+    model: String(provider.model || "").trim(),
+    protocol: normalizeLlmProtocol(provider.protocol),
+    temperature: Number(provider.temperature ?? form.temperature ?? 0.3),
+    weight: Math.max(1, Math.min(100, Number(provider.weight || 1))),
+    enabled: provider.enabled !== false,
+  };
+}
+
+function buildLlmProviders() {
+  return form.llm_providers.map(buildLlmProvider);
+}
+
+function invalidateSingleKey() {
+  form.key_ref = "";
+  form.api_key_set = false;
+  singleModels.value = [];
+  singleModelsError.value = "";
+  llmTest.value = null;
+}
+
+function invalidateProviderKey(provider) {
+  if (!provider) return;
+  provider.key_ref = "";
+  provider.api_key_set = false;
+  provider.api_key_masked = "";
+  provider.health_ref = "";
+  provider.health = {};
+  provider.models = [];
+  provider.modelsError = "";
+  llmTest.value = null;
+}
+
+function validateLlmProviders() {
+  if (llmMode.value !== "pool") {
+    if (!String(form.base_url || "").trim() || !String(form.model || "").trim()
+      || (!String(form.api_key || "").trim() && !form.key_ref)) {
+      throw new Error("单端点配置缺少 base_url、api_key 或模型");
+    }
+    return;
+  }
+  if (!form.llm_providers.length) throw new Error("端点池至少需要一个端点");
+  for (const [idx, provider] of buildLlmProviders().entries()) {
+    if (!provider.name || !provider.base_url || !provider.model || (!provider.api_key && !provider.key_ref)) {
+      throw new Error(`LLM 端点 #${idx + 1} 缺少名称、base_url、api_key 或模型`);
+    }
+  }
+  if (!form.llm_providers.some((provider) => provider.enabled !== false)) {
+    throw new Error("端点池至少需要启用一个端点");
+  }
+}
+
+function resultText(item) {
+  if (!item) return "";
+  const parts = [];
+  if (item.protocol) parts.push(item.protocol);
+  if (item.model) parts.push(item.model);
+  if (item.latency_ms) parts.push(`${item.latency_ms}ms`);
+  if (item.ok && item.reply) parts.push(`reply: ${item.reply}`);
+  if (!item.ok && item.error) parts.push(item.error);
+  return parts.join(" · ");
+}
+
+function applyLlmHealthResults(results = []) {
+  for (const item of results) {
+    const provider = form.llm_providers.find((row) =>
+      (row.name && item.name && row.name === item.name)
+      || (row.base_url === item.base_url && row.model === item.model)
+    );
+    if (!provider) continue;
+    provider.health = {
+      status: item.ok ? "ok" : "failed",
+      last_seen: new Date().toISOString(),
+      last_error: item.ok ? "" : (item.error || "测试失败"),
+    };
+  }
+}
+
+async function refreshProviderHealth() {
+  if (llmMode.value !== "pool" || !form.llm_providers.length) return;
+  const res = await api.providerHealth();
+  const byRef = new Map((res.providers || []).map((item) => [item.health_ref, item.health || {}]));
+  for (const provider of form.llm_providers) {
+    if (provider.health_ref && byRef.has(provider.health_ref)) {
+      provider.health = byRef.get(provider.health_ref);
+    }
+  }
+}
+
+async function loadSingleModels() {
+  singleModelsLoading.value = true;
+  singleModelsError.value = "";
+  try {
+    const res = await api.listModels({
+      base_url: form.base_url,
+      api_key: form.api_key.trim(),
+      key_ref: form.key_ref,
+      model: form.model,
+      protocol: form.protocol,
+    });
+    if (res?.ok && res.models?.length) {
+      singleModels.value = res.models;
+      if (!form.model || !singleModels.value.includes(form.model)) form.model = singleModels.value[0];
+      toast(`已获取 ${res.models.length} 个模型`);
+    } else {
+      singleModels.value = [];
+      singleModelsError.value = res?.error || "未获取到模型列表";
+      toast("获取模型失败");
+    }
+  } catch (e) {
+    singleModels.value = [];
+    singleModelsError.value = String(e.message || e).replace(/^\d+\s*/, "");
+    toast("获取模型失败");
+  } finally {
+    singleModelsLoading.value = false;
+  }
+}
+
+async function loadProviderModels(idx) {
+  const provider = form.llm_providers[idx];
+  if (!provider) return;
+  provider.modelsLoading = true;
+  provider.modelsError = "";
+  try {
+    const res = await api.listModels({
+      base_url: provider.base_url,
+      api_key: String(provider.api_key || "").trim(),
+      protocol: provider.protocol,
+      key_ref: provider.key_ref,
+      model: provider.model,
+    });
+    if (res?.ok && res.models?.length) {
+      provider.models = res.models;
+      if (!provider.model || !provider.models.includes(provider.model)) provider.model = provider.models[0];
+      toast(`已获取 ${res.models.length} 个模型`);
+    } else {
+      provider.models = [];
+      provider.modelsError = res?.error || "未获取到模型列表";
+      toast(`端点 #${idx + 1} 获取模型失败`);
+    }
+  } catch (e) {
+    provider.models = [];
+    provider.modelsError = String(e.message || e).replace(/^\d+\s*/, "");
+    toast(`端点 #${idx + 1} 获取模型失败`);
+  } finally {
+    provider.modelsLoading = false;
+  }
+}
+
+async function testSingleLlm() {
+  testingLlm.value = true;
+  llmTest.value = null;
+  try {
+    const res = await api.testLLM({
+      base_url: form.base_url,
+      api_key: form.api_key.trim(),
+      key_ref: form.key_ref,
+      model: form.model,
+      protocol: form.protocol,
+      temperature: Number(form.temperature),
+    });
+    llmTest.value = res;
+    toast(res.ok ? "LLM 测试通过" : "LLM 测试失败");
+  } catch (e) {
+    llmTest.value = { ok: false, results: [], error: String(e.message || e).replace(/^\d+\s*/, "") };
+    toast("LLM 测试失败");
+  } finally {
+    testingLlm.value = false;
+  }
+}
+
+async function testLlmProvider(idx) {
+  const provider = form.llm_providers[idx];
+  if (!provider) return;
+  provider.testing = true;
+  llmTest.value = null;
+  try {
+    const payload = buildLlmProvider(provider);
+    if (!payload.base_url || !payload.model || (!payload.api_key && !payload.key_ref)) {
+      throw new Error(`LLM 端点 #${idx + 1} 配置不完整`);
+    }
+    const res = await api.testLLM({ providers: [payload] });
+    llmTest.value = res;
+    applyLlmHealthResults(res.results || []);
+    toast(res.ok ? `端点 #${idx + 1} 测试通过` : `端点 #${idx + 1} 测试失败`);
+  } catch (e) {
+    llmTest.value = { ok: false, results: [], error: String(e.message || e).replace(/^\d+\s*/, "") };
+    toast(`端点 #${idx + 1} 测试失败`);
+  } finally {
+    provider.testing = false;
+  }
+}
+
 async function load() {
   loading.value = true;
   try {
@@ -102,9 +412,14 @@ async function load() {
     meta.value = { updated_at: s.updated_at };
     form.base_url = s.llm?.base_url || "";
     form.model = s.llm?.model || "";
+    form.protocol = normalizeLlmProtocol(s.llm?.protocol);
     form.temperature = s.llm?.temperature ?? 0.3;
     form.api_key = "";
+    form.key_ref = s.llm?.key_ref || "";
     form.api_key_set = s.llm?.api_key_set;
+    llmMode.value = s.llm?.mode === "pool" ? "pool" : "single";
+    form.llm_provider_count = s.llm?.provider_count || 0;
+    loadLlmProviders(s.llm?.providers || []);
     form.fofa_key = "";
     form.fofa_key_set = s.fofa?.key_set;
     form.fofa_base_url = s.fofa?.base_url || "";
@@ -122,11 +437,15 @@ async function load() {
 async function save() {
   saving.value = true;
   try {
+    validateLlmProviders();
     const body = {
       llm: {
+        mode: llmMode.value,
         base_url: form.base_url,
         model: form.model,
+        protocol: form.protocol,
         temperature: Number(form.temperature),
+        providers: buildLlmProviders(),
       },
       fofa: {
         base_url: form.fofa_base_url,
@@ -147,6 +466,11 @@ async function save() {
     form.api_key = "";
     form.fofa_key = "";
     form.api_key_set = s.llm?.api_key_set;
+    form.key_ref = s.llm?.key_ref || "";
+    llmMode.value = s.llm?.mode === "pool" ? "pool" : "single";
+    form.protocol = normalizeLlmProtocol(s.llm?.protocol);
+    form.llm_provider_count = s.llm?.provider_count || 0;
+    loadLlmProviders(s.llm?.providers || []);
     form.fofa_key_set = s.fofa?.key_set;
     toast("系统配置已保存");
   } catch (e) {
@@ -156,11 +480,14 @@ async function save() {
   }
 }
 
-onMounted(() => {
-  load();
+onMounted(async () => {
+  await load();
+  refreshProviderHealth().catch(() => {});
+  healthPoll = setInterval(() => refreshProviderHealth().catch(() => {}), 10000);
   // 探测后端是否支持更新 API（原版不注册 → supported=false → 隐藏区块）
   checkUpdate();
 });
+onUnmounted(() => clearInterval(healthPoll));
 </script>
 
 <template>
@@ -183,9 +510,11 @@ onMounted(() => {
         <div class="settings-health">
           <div>
             <span>LLM</span>
-            <b>{{ form.model || "未设置模型" }}</b>
+            <b>{{ llmMode === "pool" ? `${form.llm_providers.length} 个端点` : (form.model || "未设置模型") }}</b>
           </div>
-          <i :class="{ on: form.api_key_set }">{{ form.api_key_set ? "key set" : "no key" }}</i>
+          <i :class="{ on: llmMode === 'pool' ? form.llm_providers.some((p) => p.enabled !== false) : form.api_key_set }">
+            {{ llmMode === "pool" ? "pool" : (form.api_key_set ? "key set" : "no key") }}
+          </i>
         </div>
         <div class="settings-health">
           <div>
@@ -219,19 +548,173 @@ onMounted(() => {
             <span>AI / LLM</span>
             <small>Worker、Reviewer、报告助手共用的默认模型通道</small>
           </legend>
-          <div class="settings-grid">
+          <div class="llm-mode-switch" role="tablist" aria-label="LLM 调用模式">
+            <button
+              type="button"
+              role="tab"
+              :aria-selected="llmMode === 'single'"
+              :class="{ active: llmMode === 'single' }"
+              @click="llmMode = 'single'; llmTest = null"
+            >单端点</button>
+            <button
+              type="button"
+              role="tab"
+              :aria-selected="llmMode === 'pool'"
+              :class="{ active: llmMode === 'pool' }"
+              @click="llmMode = 'pool'; llmTest = null"
+            >端点池</button>
+          </div>
+
+          <div v-if="llmMode === 'single'" class="settings-grid llm-config-pane">
             <label class="full">base_url
-              <input v-model="form.base_url" placeholder="https://api.deepseek.com/v1" />
+              <input v-model="form.base_url" required placeholder="https://api.deepseek.com/v1" @input="invalidateSingleKey" />
             </label>
-            <p class="field-hint full">OpenAI 兼容接口地址（官方或自建均可），路径需要包含 <code>/v1</code>。</p>
             <label class="full">api_key
               <input v-model="form.api_key" type="password"
+                :required="!form.key_ref"
                 :placeholder="form.api_key_set ? '已配置，留空不修改' : 'sk-...'" />
             </label>
-            <label>模型名 <input v-model="form.model" placeholder="deepseek-v4-flash" /></label>
+            <label>协议
+              <select v-model="form.protocol" @change="invalidateSingleKey">
+                <option value="auto">自动判断</option>
+                <option value="openai_chat">OpenAI Chat</option>
+                <option value="anthropic_messages">Anthropic Messages</option>
+              </select>
+            </label>
             <label>temperature
               <input v-model="form.temperature" type="number" step="0.1" min="0" max="2" />
             </label>
+            <label class="full">模型名
+              <div class="model-picker">
+                <input v-model="form.model" required list="single-llm-models" placeholder="deepseek-chat" />
+                <datalist id="single-llm-models">
+                  <option v-for="model in singleModels" :key="model" :value="model" />
+                </datalist>
+                <button type="button" :disabled="singleModelsLoading" @click="loadSingleModels">
+                  {{ singleModelsLoading ? "查询中…" : "查询模型" }}
+                </button>
+              </div>
+              <small v-if="singleModelsError" class="model-hint">{{ singleModelsError }}</small>
+            </label>
+            <div class="settings-test full">
+              <button type="button" :disabled="testingLlm" @click="testSingleLlm">
+                {{ testingLlm ? "测试中…" : "测试连接" }}
+              </button>
+            </div>
+          </div>
+
+          <div v-else class="llm-pool-pane">
+            <div class="llm-pool-toolbar">
+              <div>
+                <b>端点列表</b>
+                <span>{{ form.llm_providers.length }} 个</span>
+              </div>
+              <button type="button" @click="addLlmProvider">+ 添加端点</button>
+            </div>
+
+            <div v-if="!form.llm_providers.length" class="provider-empty">
+              <span>端点池为空</span>
+              <button type="button" @click="addLlmProvider">+ 添加端点</button>
+            </div>
+
+            <div v-else class="provider-selector" role="listbox" aria-label="LLM 端点列表">
+              <button
+                v-for="(provider, idx) in form.llm_providers"
+                :key="`${idx}:${provider.name}:${provider.base_url}:${provider.protocol}:${provider.key_ref || 'new'}`"
+                type="button"
+                role="option"
+                :aria-selected="selectedLlmProvider === idx"
+                class="provider-selector-row"
+                :class="[{ active: selectedLlmProvider === idx, disabled: provider.enabled === false }, `health-${providerHealthClass(provider)}`]"
+                @click="selectedLlmProvider = idx"
+              >
+                <span class="provider-dot" :class="providerHealthClass(provider)"></span>
+                <b>{{ provider.name || `llm-${idx + 1}` }}</b>
+                <small>{{ provider.model || "未设置模型" }}</small>
+                <em>{{ provider.protocol === "auto" ? "Auto" : provider.protocol === "anthropic_messages" ? "Anthropic" : "OpenAI" }}</em>
+                <i>权重 {{ provider.weight || 1 }}</i>
+              </button>
+            </div>
+
+            <div v-if="selectedLlm" class="provider-detail">
+              <div class="provider-detail-head">
+                <div>
+                  <span>端点 {{ selectedLlmProvider + 1 }}</span>
+                  <strong class="provider-health" :class="providerHealthClass(selectedLlm)" :title="providerHealthTitle(selectedLlm)">
+                    {{ providerHealthText(selectedLlm) }}
+                  </strong>
+                </div>
+                <div class="provider-head-actions">
+                  <button type="button" title="上移" aria-label="上移端点" :disabled="selectedLlmProvider === 0" @click="moveLlmProvider(selectedLlmProvider, -1)">↑</button>
+                  <button type="button" title="下移" aria-label="下移端点" :disabled="selectedLlmProvider === form.llm_providers.length - 1" @click="moveLlmProvider(selectedLlmProvider, 1)">↓</button>
+                  <label class="provider-enabled">
+                    <input v-model="selectedLlm.enabled" type="checkbox" />
+                    启用
+                  </label>
+                  <button type="button" class="danger" title="删除" aria-label="删除端点" @click="removeLlmProvider(selectedLlmProvider)">×</button>
+                </div>
+              </div>
+
+              <div class="provider-fields">
+                <label>名称 <input v-model="selectedLlm.name" placeholder="primary" /></label>
+                <label>协议
+                  <select v-model="selectedLlm.protocol" @change="invalidateProviderKey(selectedLlm)">
+                    <option value="auto">自动判断</option>
+                    <option value="openai_chat">OpenAI Chat</option>
+                    <option value="anthropic_messages">Anthropic Messages</option>
+                  </select>
+                </label>
+                <label class="wide">base_url
+                  <input v-model="selectedLlm.base_url" placeholder="https://api.deepseek.com/v1" @input="invalidateProviderKey(selectedLlm)" />
+                </label>
+                <label>api_key
+                  <input
+                    v-model="selectedLlm.api_key"
+                    type="password"
+                    :required="!selectedLlm.key_ref"
+                    :placeholder="selectedLlm.api_key_set ? `${selectedLlm.api_key_masked}，留空不修改` : 'sk-...'"
+                  />
+                </label>
+                <label>temperature
+                  <input v-model="selectedLlm.temperature" type="number" step="0.1" min="0" max="2" />
+                </label>
+                <label>权重
+                  <input v-model="selectedLlm.weight" type="number" min="1" max="100" />
+                </label>
+                <label class="wide">模型名
+                  <div class="model-picker">
+                    <input
+                      v-model="selectedLlm.model"
+                      :list="`llm-provider-models-${selectedLlmProvider}`"
+                      placeholder="deepseek-chat"
+                    />
+                    <datalist :id="`llm-provider-models-${selectedLlmProvider}`">
+                      <option v-for="model in selectedLlm.models" :key="model" :value="model" />
+                    </datalist>
+                    <button type="button" :disabled="selectedLlm.modelsLoading" @click="loadProviderModels(selectedLlmProvider)">
+                      {{ selectedLlm.modelsLoading ? "查询中…" : "查询模型" }}
+                    </button>
+                  </div>
+                  <small v-if="selectedLlm.modelsError" class="model-hint">{{ selectedLlm.modelsError }}</small>
+                </label>
+                <div class="provider-test wide">
+                  <button type="button" :disabled="selectedLlm.testing" @click="testLlmProvider(selectedLlmProvider)">
+                    {{ selectedLlm.testing ? "测试中…" : "测试当前端点" }}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="llmTest" class="settings-test-result" :class="{ ok: llmTest.ok }">
+            <b>{{ llmTest.ok ? "LLM 可用" : "LLM 不可用" }}</b>
+            <p v-if="llmTest.error">{{ llmTest.error }}</p>
+            <ul v-if="llmTest.results?.length">
+              <li v-for="item in llmTest.results" :key="`${item.name}-${item.base_url}`" :class="{ ok: item.ok }">
+                <strong>{{ item.ok ? "通过" : "失败" }} · {{ item.name || "single" }}</strong>
+                <small>{{ resultText(item) }}</small>
+              </li>
+            </ul>
           </div>
         </fieldset>
 

--- a/tests/test_llm_cooldown_flow.py
+++ b/tests/test_llm_cooldown_flow.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.agents.worker import Worker
+from app.llm.client import LLMError
+from app.orchestrator import TaskRunner
+from app.schemas import Verdict, WorkerResult
+
+
+class WorkerCooldownTests(unittest.TestCase):
+    def test_worker_propagates_provider_cooldown(self) -> None:
+        worker = Worker.__new__(Worker)
+        worker.deepen_context = None
+        worker.target = "https://example.invalid"
+        worker.src_type = "enterprise"
+        worker.prompt_version = "test"
+        worker.cancel_event = threading.Event()
+        worker.findings = []
+        worker._js_tool_enabled = False
+        worker._intel_block = Mock(return_value="")
+        worker._duplicate_block = Mock(return_value="")
+        worker._emit = Mock()
+        worker._route_rounds = Mock(return_value=(1, 1))
+        worker.executor = SimpleNamespace(session_status_block=Mock(return_value=""))
+        worker.llm = SimpleNamespace(
+            chat=Mock(side_effect=LLMError("provider_cooldown", "all providers cooling", retry_after=17))
+        )
+
+        result = worker.run()
+
+        self.assertEqual(result.verdict, Verdict.error)
+        self.assertEqual(result.failure_kind, "provider_cooldown")
+        self.assertEqual(result.retry_after_seconds, 17)
+
+    def test_worker_result_cooldown_fields_default_to_no_delay(self) -> None:
+        result = WorkerResult(target="x", verdict=Verdict.no_vuln)
+
+        self.assertEqual(result.failure_kind, "")
+        self.assertEqual(result.retry_after_seconds, 0)
+
+
+class _SessionContext:
+    def __init__(self, session) -> None:
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class OrchestratorCooldownTests(unittest.IsolatedAsyncioTestCase):
+    async def test_provider_cooldown_requeues_without_consuming_retry(self) -> None:
+        target = SimpleNamespace(
+            assigned_worker="worker-1",
+            url="https://example.invalid",
+            host="example.invalid",
+            source="manual",
+            status="scanning",
+            verdict="error",
+            heartbeat_at=object(),
+            last_error="",
+            dead_reason="",
+            retry_count=2,
+        )
+        session = SimpleNamespace(get=AsyncMock(return_value=target), commit=AsyncMock(), add=Mock())
+        runner = TaskRunner("task-1")
+        runner._harvest_intel = AsyncMock()
+        runner._log = AsyncMock()
+        result = {
+            "verdict": Verdict.error.value,
+            "findings": [],
+            "error": "LLM 调用失败: all providers cooling",
+            "failure_kind": "provider_cooldown",
+            "retry_after_seconds": 17,
+        }
+
+        with patch("app.orchestrator.SessionLocal", return_value=_SessionContext(session)):
+            await runner._persist_worker_result("task-1", "target-1", result)
+
+        self.assertEqual(target.status, "queued")
+        self.assertEqual(target.verdict, "")
+        self.assertEqual(target.retry_count, 2)
+        self.assertEqual(target.assigned_worker, "")
+        self.assertIn("target-1", runner._llm_provider_retry_after)
+        self.assertGreater(runner._llm_pool_retry_after, 0)
+        runner._log.assert_awaited_once()
+
+        blocked_session = SimpleNamespace(execute=AsyncMock(side_effect=AssertionError("must not query")))
+        self.assertIsNone(await runner._pop_queued(blocked_session))
+
+    async def test_model_behavior_failure_requeues_instead_of_marking_dead(self) -> None:
+        target = SimpleNamespace(
+            assigned_worker="worker-1",
+            url="https://example.invalid",
+            host="example.invalid",
+            source="manual",
+            status="scanning",
+            verdict="error",
+            heartbeat_at=object(),
+            last_error="",
+            dead_reason="",
+            retry_count=0,
+        )
+        session = SimpleNamespace(get=AsyncMock(return_value=target), commit=AsyncMock(), add=Mock())
+        runner = TaskRunner("task-1")
+        runner._harvest_intel = AsyncMock()
+        runner._log = AsyncMock()
+
+        with patch("app.orchestrator.SessionLocal", return_value=_SessionContext(session)):
+            await runner._persist_worker_result("task-1", "target-1", {
+                "verdict": Verdict.error.value,
+                "findings": [],
+                "error": "模型连续空转，本轮未得到可靠结论。",
+                "failure_kind": "model_behavior",
+            })
+
+        self.assertEqual(target.status, "queued")
+        self.assertEqual(target.verdict, "")
+        self.assertEqual(target.assigned_worker, "")
+        self.assertEqual(runner._transient_llm_requeue["target-1"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_endpoint_hardening.py
+++ b/tests/test_llm_endpoint_hardening.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_DOTENV = PROJECT_ROOT / ".env"
+_path_exists = Path.exists
+_path_read_text = Path.read_text
+
+
+def _is_project_dotenv(path: Path) -> bool:
+    return path.resolve() == PROJECT_DOTENV.resolve()
+
+
+def _exists_without_project_dotenv(path: Path) -> bool:
+    return False if _is_project_dotenv(path) else _path_exists(path)
+
+
+def _read_text_without_project_dotenv(path: Path, *args, **kwargs) -> str:
+    if _is_project_dotenv(path):
+        raise AssertionError("Tests must not read the project .env file")
+    return _path_read_text(path, *args, **kwargs)
+
+
+with (
+    patch.object(Path, "exists", _exists_without_project_dotenv),
+    patch.object(Path, "read_text", _read_text_without_project_dotenv),
+):
+    from app import settings_service
+    from app.api import settings as settings_api
+    from app.api import tasks as tasks_api
+    from app.api.dto import PartialModelConfigDTO, UpdateTaskRequest
+    from app.config import LLMConfig
+    from app.llm import client as client_module
+    from app.llm import health
+
+
+GLOBAL_KEY = "global-key-for-tests"
+POOL_KEY = "pool-key-for-tests"
+GLOBAL_PROVIDER = {
+    "base_url": "https://global.example/v1",
+    "api_key": GLOBAL_KEY,
+    "model": "global-model",
+    "protocol": "openai_chat",
+}
+POOL_PROVIDER = {
+    "name": "pool-primary",
+    "base_url": "https://pool.example/v1",
+    "api_key": POOL_KEY,
+    "model": "pool-model",
+    "protocol": "openai_chat",
+    "enabled": True,
+}
+
+
+def _settings() -> dict:
+    return {
+        "llm": {
+            "mode": "pool",
+            **GLOBAL_PROVIDER,
+            "temperature": 0.3,
+            "providers": [POOL_PROVIDER],
+        },
+        "fofa": {},
+        "engines": {},
+        "defaults": {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_health_state():
+    with health._LOCK:
+        health._HEALTH.clear()
+    yield
+    with health._LOCK:
+        health._HEALTH.clear()
+
+
+def test_behavior_probe_retry_delay_is_capped():
+    base_url = "https://behavior-probe.example/v1"
+    model = "behavior-model"
+    api_key = "behavior-key"
+    ref = health.provider_ref(base_url, model, api_key)
+
+    with (
+        patch.object(health, "_BEHAVIOR_FAIL_THRESHOLD", 1),
+        patch.object(health, "_BEHAVIOR_PROBE_SECONDS", 900),
+    ):
+        health.mark_provider_behavior_failed(base_url, model, "behavior failure", api_key)
+        with health._LOCK:
+            health._HEALTH[ref]["behavior_cooldown_until_ts"] = 0
+        assert health.acquire_provider_slot(base_url, model, api_key, owner="worker-a")[0]
+        assert 1 <= health.provider_retry_after_seconds(base_url, model, api_key) <= 5
+
+
+def test_behavior_half_open_probe_is_not_claimed_while_transport_is_blocked():
+    base_url = "https://blocked-transport.example/v1"
+    model = "behavior-model"
+    api_key = "behavior-key"
+    ref = health.provider_ref(base_url, model, api_key)
+
+    health.mark_provider_behavior_failed(base_url, model, "behavior failure", api_key)
+    health.mark_provider_failed(base_url, model, "transport failure", api_key)
+    with health._LOCK:
+        health._HEALTH[ref]["behavior_retry_at_ts"] = 0
+
+    assert health.acquire_provider_slot(
+        base_url, model, api_key, owner="worker-a"
+    ) == (False, "failed")
+    with health._LOCK:
+        assert health._HEALTH[ref].get("behavior_probe_owner") in (None, "")
+        health._HEALTH[ref]["failed_retry_at_ts"] = 0
+
+    assert health.acquire_provider_slot(
+        base_url, model, api_key, owner="worker-b"
+    ) == (True, "half_open")
+    with health._LOCK:
+        assert health._HEALTH[ref]["behavior_probe_owner"] == "worker-b"
+
+
+def test_failure_callback_exception_does_not_break_failover():
+    primary = LLMConfig(
+        base_url="https://primary.example/v1",
+        api_key="primary-key",
+        model="primary-model",
+        protocol="openai_chat",
+    )
+    secondary = LLMConfig(
+        base_url="https://secondary.example/v1",
+        api_key="secondary-key",
+        model="secondary-model",
+        protocol="openai_chat",
+    )
+    callback = Mock(side_effect=RuntimeError("callback failure"))
+    first_error = client_module.LLMError("network", "primary failed")
+    expected = object()
+
+    with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+        llm = client_module.LLMClient(
+            providers=[primary, secondary],
+            on_provider_failure=callback,
+        )
+        with (
+            patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+            patch.object(llm, "_chat_current_provider", side_effect=[first_error, expected]),
+            patch.object(client_module.logger, "exception") as logged,
+        ):
+            assert llm.chat([{"role": "user", "content": "test"}]) is expected
+
+    callback.assert_called_once()
+    logged.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "api_key: abcdefghijk",
+        '"api_key":"abcdefghijk"',
+        "token=abcdefghijk",
+        "password = secret123",
+        "x-api-key: abcdefghijk",
+    ],
+)
+def test_safe_error_masks_common_secret_fields(value: str):
+    assert "abcdefghijk" not in settings_api._safe_error(value)
+    assert "secret123" not in settings_api._safe_error(value)
+
+
+def test_safe_error_masks_exact_nonstandard_provider_key():
+    assert POOL_KEY not in settings_api._safe_error(
+        f"credential rejected: {POOL_KEY}", POOL_KEY
+    )
+
+
+def _update_llm_settings(current_llm: dict, llm_update: dict):
+    row = SimpleNamespace(llm=dict(current_llm), fofa={}, engines={}, defaults={})
+    session = SimpleNamespace(
+        get=AsyncMock(return_value=row),
+        add=Mock(),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    current = {
+        "llm": dict(current_llm),
+        "fofa": {},
+        "engines": {},
+        "defaults": {},
+    }
+    with (
+        patch.object(settings_service, "effective_settings", return_value=current),
+        patch.object(settings_service, "refresh_cache", new=AsyncMock()),
+        patch.object(settings_service, "public_settings_view", return_value={}),
+    ):
+        asyncio.run(settings_service.update_settings(session, {"llm": llm_update}))
+    return row
+
+
+@pytest.mark.parametrize(
+    "llm_update",
+    [
+        {"base_url": "https://changed.example/v1"},
+        {"protocol": "anthropic_messages"},
+    ],
+)
+def test_single_settings_endpoint_change_clears_stored_key(llm_update: dict):
+    row = _update_llm_settings(
+        {**GLOBAL_PROVIDER, "mode": "single", "temperature": 0.3},
+        llm_update,
+    )
+    assert "api_key" not in row.llm
+
+
+def test_single_settings_model_change_keeps_stored_key():
+    row = _update_llm_settings(
+        {**GLOBAL_PROVIDER, "mode": "single", "temperature": 0.3},
+        {"model": "new-model"},
+    )
+    assert row.llm["api_key"] == GLOBAL_KEY
+
+
+def test_single_settings_endpoint_change_accepts_explicit_new_key():
+    replacement = "replacement-key-for-tests"
+    row = _update_llm_settings(
+        {**GLOBAL_PROVIDER, "mode": "single", "temperature": 0.3},
+        {
+            "base_url": "https://changed.example/v1",
+            "api_key": replacement,
+        },
+    )
+    assert row.llm["api_key"] == replacement
+
+
+def test_key_only_update_snapshots_endpoint_identity():
+    db_key = "db-key-for-tests"
+    current_llm = {
+        **GLOBAL_PROVIDER,
+        "api_key": "env-key-for-tests",
+        "mode": "single",
+        "temperature": 0.3,
+    }
+    row = SimpleNamespace(llm={}, fofa={}, engines={}, defaults={})
+    session = SimpleNamespace(
+        get=AsyncMock(return_value=row),
+        add=Mock(),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    with (
+        patch.object(settings_service, "effective_settings", return_value={
+            "llm": current_llm,
+            "fofa": {},
+            "engines": {},
+            "defaults": {},
+        }),
+        patch.object(settings_service, "refresh_cache", new=AsyncMock()),
+        patch.object(settings_service, "public_settings_view", return_value={}),
+    ):
+        asyncio.run(settings_service.update_settings(
+            session, {"llm": {"api_key": db_key}}
+        ))
+
+    assert row.llm["base_url"] == GLOBAL_PROVIDER["base_url"]
+    assert row.llm["protocol"] == GLOBAL_PROVIDER["protocol"]
+
+    changed_env = {
+        "LLM_PROVIDERS_JSON": "",
+        "LLM_BASE_URL": "https://changed-env.example/v1",
+        "LLM_API_KEY": "changed-env-key-for-tests",
+        "LLM_MODEL": GLOBAL_PROVIDER["model"],
+        "LLM_PROTOCOL": GLOBAL_PROVIDER["protocol"],
+    }
+    cache = {"llm": row.llm, "fofa": {}, "engines": {}, "defaults": {}}
+    with (
+        patch.dict(os.environ, changed_env, clear=False),
+        patch.object(settings_service, "_cache", cache),
+    ):
+        assert settings_service.resolve_llm_key_for_identity(
+            GLOBAL_PROVIDER["base_url"],
+            GLOBAL_PROVIDER["model"],
+            GLOBAL_PROVIDER["protocol"],
+        ) == db_key
+        assert settings_service.resolve_llm_key_for_identity(
+            changed_env["LLM_BASE_URL"],
+            GLOBAL_PROVIDER["model"],
+            GLOBAL_PROVIDER["protocol"],
+        ) == changed_env["LLM_API_KEY"]
+
+
+def test_public_single_key_state_uses_endpoint_bound_key():
+    cache = {
+        "llm": {
+            "mode": "single",
+            "base_url": "https://db.example/v1",
+            "model": "db-model",
+            "protocol": "openai_chat",
+        },
+        "fofa": {},
+        "engines": {},
+        "defaults": {},
+        "updated_at": None,
+    }
+    env = {
+        "LLM_PROVIDER_MODE": "single",
+        "LLM_PROVIDERS_JSON": "",
+        "LLM_BASE_URL": "https://env.example/v1",
+        "LLM_API_KEY": GLOBAL_KEY,
+        "LLM_MODEL": "env-model",
+        "LLM_PROTOCOL": "openai_chat",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch.object(settings_service, "_cache", cache),
+        patch.object(settings_service, "list_engines", return_value=[]),
+        patch.object(settings_service, "llm_health_snapshot", return_value={}),
+    ):
+        public = settings_service.public_settings_view()["llm"]
+
+    assert public["api_key"] == ""
+    assert public["api_key_set"] is False
+    assert public["key_ref"] == ""
+
+
+def test_db_single_key_overrides_env_key_for_same_endpoint():
+    db_key = "db-replacement-key-for-tests"
+    cache = {
+        "llm": {
+            "mode": "single",
+            **GLOBAL_PROVIDER,
+            "api_key": db_key,
+        },
+        "fofa": {},
+        "engines": {},
+        "defaults": {},
+        "updated_at": None,
+    }
+    env = {
+        "LLM_PROVIDER_MODE": "single",
+        "LLM_PROVIDERS_JSON": "",
+        "LLM_BASE_URL": GLOBAL_PROVIDER["base_url"],
+        "LLM_API_KEY": GLOBAL_KEY,
+        "LLM_MODEL": GLOBAL_PROVIDER["model"],
+        "LLM_PROTOCOL": GLOBAL_PROVIDER["protocol"],
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch.object(settings_service, "_cache", cache),
+        patch.object(settings_service, "list_engines", return_value=[]),
+        patch.object(settings_service, "llm_health_snapshot", return_value={}),
+    ):
+        providers = settings_service.resolve_llm_providers()
+        public = settings_service.public_settings_view()["llm"]
+
+    assert providers[0].api_key == db_key
+    assert public["key_ref"] == settings_service.secret_ref(db_key)
+
+
+@pytest.mark.parametrize(
+    "model_patch",
+    [
+        PartialModelConfigDTO(base_url="https://changed.example/v1"),
+        PartialModelConfigDTO(protocol="anthropic_messages"),
+        PartialModelConfigDTO(
+            base_url="https://changed.example/v1",
+            api_key="********",
+        ),
+    ],
+)
+def test_fixed_task_endpoint_change_drops_embedded_key(model_patch):
+    task = SimpleNamespace(
+        model_config_json={"inherit_global": False, **GLOBAL_PROVIDER},
+        fofa_query="",
+    )
+    session = SimpleNamespace(
+        get=AsyncMock(return_value=task),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    request = UpdateTaskRequest(model_config_data=model_patch)
+    current = _settings()
+    current["llm"]["mode"] = "single"
+
+    async def run_update():
+        with (
+            patch.object(settings_service, "effective_settings", return_value=current),
+            patch.object(tasks_api, "_compute_stats", new=AsyncMock(return_value=Mock())),
+            patch.object(tasks_api, "_task_to_dto", return_value={"ok": True}),
+        ):
+            return await tasks_api.update_task("task-1", request, session)
+
+    assert asyncio.run(run_update()) == {"ok": True}
+    assert "api_key" not in task.model_config_json
+
+
+def test_models_probe_does_not_use_ref_or_global_key_for_arbitrary_url():
+    with patch.object(settings_service, "effective_settings", return_value=_settings()):
+        result = asyncio.run(settings_service.list_available_models(
+            base_url="https://arbitrary.example/v1",
+            protocol="openai_chat",
+            key_ref=settings_service.secret_ref(POOL_KEY),
+            model="pool-model",
+        ))
+    assert result["ok"] is False
+    assert result["models"] == []
+    assert "API Key" in result["error"]
+
+
+def test_models_probe_can_reuse_masked_provider_identity():
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"id": "pool-model"}]}
+
+    class AsyncClient:
+        captured = None
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, headers):
+            AsyncClient.captured = (url, headers)
+            return Response()
+
+    with (
+        patch.object(settings_service, "effective_settings", return_value=_settings()),
+        patch("httpx.AsyncClient", AsyncClient),
+        patch("app.tools.netguard.assert_safe_outbound_url"),
+    ):
+        result = asyncio.run(settings_service.list_available_models(
+            base_url=POOL_PROVIDER["base_url"],
+            protocol=POOL_PROVIDER["protocol"],
+            key_ref=settings_service.secret_ref(POOL_KEY),
+        ))
+
+    assert result["ok"] is True
+    assert AsyncClient.captured[1]["Authorization"] == f"Bearer {POOL_KEY}"
+
+
+@pytest.mark.parametrize(
+    ("protocol", "model", "expected_url"),
+    [
+        ("openai_chat", "gpt-4o", "https://relay.example/v1/chat/completions"),
+        ("anthropic_messages", "claude-3-5-sonnet", "https://relay.example/v1/messages"),
+    ],
+)
+def test_llm_connection_probe_uses_runtime_user_agent(protocol, model, expected_url):
+    class Response:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "choices": [{"message": {"content": "ok"}}],
+                "content": [{"type": "text", "text": "ok"}],
+            }
+
+    class AsyncClient:
+        captured = None
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, headers, json):
+            AsyncClient.captured = (url, headers, json)
+            return Response()
+
+    provider = LLMConfig(
+        base_url="https://relay.example/v1",
+        api_key=POOL_KEY,
+        model=model,
+        protocol=protocol,
+    )
+    with (
+        patch("httpx.AsyncClient", AsyncClient),
+        patch.object(settings_api, "assert_safe_outbound_url"),
+        patch.object(settings_api, "_resolve_user_agent", return_value="probe-UA/1.0") as resolve_ua,
+        patch.object(settings_api, "mark_provider_ok"),
+    ):
+        result = asyncio.run(settings_api._test_llm_one("probe", provider))
+
+    assert result["ok"] is True
+    assert AsyncClient.captured[0] == expected_url
+    assert AsyncClient.captured[1]["User-Agent"] == "probe-UA/1.0"
+    assert AsyncClient.captured[1]["Accept"] == "application/json"
+    resolve_ua.assert_called_once_with(model, "https://relay.example/v1")
+    if protocol == "anthropic_messages":
+        assert AsyncClient.captured[1]["x-api-key"] == POOL_KEY

--- a/tests/test_llm_provider_pool.py
+++ b/tests/test_llm_provider_pool.py
@@ -1,0 +1,981 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import HTTPException
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_DOTENV = PROJECT_ROOT / ".env"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_path_exists = Path.exists
+_path_read_text = Path.read_text
+
+
+def _is_project_dotenv(path: Path) -> bool:
+    return os.path.normcase(os.path.abspath(path)) == os.path.normcase(str(PROJECT_DOTENV))
+
+
+def _exists_without_project_dotenv(path: Path) -> bool:
+    if _is_project_dotenv(path):
+        return False
+    return _path_exists(path)
+
+
+def _read_text_without_project_dotenv(path: Path, *args, **kwargs) -> str:
+    if _is_project_dotenv(path):
+        raise AssertionError("Tests must not read the project .env file")
+    return _path_read_text(path, *args, **kwargs)
+
+
+with (
+    patch.object(Path, "exists", _exists_without_project_dotenv),
+    patch.object(Path, "read_text", _read_text_without_project_dotenv),
+):
+    from app.config import LLMConfig
+    from app import settings_service
+    from app.api import settings as settings_api
+    from app.api import tasks as tasks_api
+    from app.api.dto import (
+        LLMSettingsDTO,
+        CreateTaskRequest,
+        ModelConfigDTO,
+        PartialModelConfigDTO,
+        SettingsUpdateRequest,
+        UpdateTaskRequest,
+    )
+    from app.llm import client as client_module
+    from app.llm import health
+
+
+FAKE_SECRET = "test-key-not-a-real-secret"
+
+
+def _provider(name: str, *, weight: int = 1) -> LLMConfig:
+    return LLMConfig(
+        base_url=f"https://{name}.invalid/v1",
+        api_key=f"{FAKE_SECRET}-{name}",
+        model=f"model-{name}",
+        protocol="openai_chat",
+        weight=weight,
+        enabled=True,
+    )
+
+
+class StateResetMixin:
+    def setUp(self) -> None:
+        with health._LOCK:
+            health._HEALTH.clear()
+        with client_module._RR_LOCK:
+            client_module._RR_STATE.clear()
+
+    def tearDown(self) -> None:
+        with health._LOCK:
+            health._HEALTH.clear()
+        with client_module._RR_LOCK:
+            client_module._RR_STATE.clear()
+
+
+class SettingsServiceTests(StateResetMixin, unittest.TestCase):
+    def test_protocol_normalization_supports_aliases_and_legacy_values(self) -> None:
+        cases = {
+            None: "auto",
+            "detect": "auto",
+            "openai": "openai_chat",
+            "chat": "openai_chat",
+            "completions": "openai_chat",
+            "messages": "anthropic_messages",
+            "anthropic": "anthropic_messages",
+            "unsupported-value": "auto",
+        }
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(settings_service.normalize_llm_protocol(value), expected)
+
+    def test_provider_cleaning_clamps_values_and_keeps_disabled_state(self) -> None:
+        providers = settings_service._clean_llm_providers([
+            {
+                "name": "disabled",
+                "base": "https://disabled.invalid/v1",
+                "key": f"{FAKE_SECRET}-disabled",
+                "model": "model-disabled",
+                "temperature": -1,
+                "weight": 0,
+                "enabled": "off",
+            },
+            {
+                "name": "heavy",
+                "base_url": "https://heavy.invalid/v1",
+                "api_key": f"{FAKE_SECRET}-heavy",
+                "model": "model-heavy",
+                "temperature": 9,
+                "weight": 999,
+            },
+            {
+                "name": "missing-key",
+                "base_url": "https://missing.invalid/v1",
+                "model": "model-missing",
+            },
+        ])
+
+        self.assertEqual(len(providers), 2)
+        self.assertFalse(providers[0]["enabled"])
+        self.assertEqual(providers[0]["weight"], 1)
+        self.assertEqual(providers[0]["temperature"], 0.0)
+        self.assertTrue(providers[1]["enabled"])
+        self.assertEqual(providers[1]["weight"], 100)
+        self.assertEqual(providers[1]["temperature"], 2.0)
+
+    def test_provider_key_round_trip_never_exposes_plaintext(self) -> None:
+        old_provider = {
+            "name": "primary",
+            "base_url": "https://primary.invalid/v1",
+            "api_key": FAKE_SECRET,
+            "model": "model-primary",
+        }
+        incoming = {
+            "name": "primary",
+            "base_url": old_provider["base_url"],
+            "api_key": "********",
+            "key_ref": settings_service.secret_ref(FAKE_SECRET),
+            "model": old_provider["model"],
+        }
+
+        preserved = settings_service._preserve_provider_keys([incoming], [old_provider])
+        self.assertEqual(preserved[0]["api_key"], FAKE_SECRET)
+
+        public = settings_service._public_llm_provider(preserved[0])
+        serialized = json.dumps(public, ensure_ascii=False)
+        self.assertNotIn(FAKE_SECRET, serialized)
+        self.assertEqual(public["api_key"], "")
+        self.assertTrue(public["api_key_set"])
+        self.assertEqual(public["key_ref"], settings_service.secret_ref(FAKE_SECRET))
+        self.assertNotEqual(settings_service.mask_secret(FAKE_SECRET), FAKE_SECRET)
+
+    def test_pool_mode_rejects_update_without_complete_enabled_provider(self) -> None:
+        body = SettingsUpdateRequest(llm=LLMSettingsDTO(
+            mode="pool",
+            providers=[{
+                "name": "disabled",
+                "base_url": "https://disabled.invalid/v1",
+                "api_key": FAKE_SECRET,
+                "model": "model-disabled",
+                "enabled": False,
+            }],
+        ))
+
+        with patch.object(settings_api, "effective_settings", return_value={"llm": {}}):
+            with self.assertRaises(HTTPException) as raised:
+                import asyncio
+                asyncio.run(settings_api.put_settings(body, Mock()))
+
+        self.assertEqual(raised.exception.status_code, 400)
+
+    def test_pool_mode_accepts_preserved_provider_key(self) -> None:
+        old_provider = {
+            "name": "primary",
+            "base_url": "https://primary.invalid/v1",
+            "api_key": FAKE_SECRET,
+            "model": "model-primary",
+            "enabled": True,
+        }
+        body = SettingsUpdateRequest(llm=LLMSettingsDTO(
+            mode="pool",
+            providers=[{
+                **old_provider,
+                "api_key": "",
+                "key_ref": settings_service.secret_ref(FAKE_SECRET),
+            }],
+        ))
+
+        async def fake_update(_session, _payload):
+            return {"ok": True}
+
+        with (
+            patch.object(
+                settings_api,
+                "effective_settings",
+                return_value={"llm": {"mode": "pool", "providers": [old_provider]}},
+            ),
+            patch.object(settings_api, "update_settings", side_effect=fake_update),
+        ):
+            import asyncio
+            result = asyncio.run(settings_api.put_settings(body, Mock()))
+
+        self.assertEqual(result, {"ok": True})
+
+    def test_explicit_global_inheritance_ignores_stale_single_override(self) -> None:
+        global_provider = {
+            "name": "global",
+            "base_url": "https://global.invalid/v1",
+            "api_key": f"{FAKE_SECRET}-global",
+            "model": "model-global",
+        }
+        task = SimpleNamespace(model_config_json={
+            "inherit_global": True,
+            "base_url": "https://stale.invalid/v1",
+            "api_key": f"{FAKE_SECRET}-stale",
+            "model": "model-stale",
+        })
+
+        with patch.object(
+            settings_service,
+            "effective_settings",
+            return_value={"llm": {
+                "mode": "pool",
+                "providers": [global_provider],
+                "temperature": 0.3,
+                "base_url": "",
+                "api_key": "",
+                "model": "",
+                "protocol": "auto",
+            }},
+        ):
+            providers = settings_service.resolve_llm_providers(task)
+
+        self.assertEqual([provider.model for provider in providers], ["model-global"])
+
+    def test_fixed_single_task_bypasses_global_pool(self) -> None:
+        task = SimpleNamespace(model_config_json={
+            "inherit_global": False,
+            "base_url": "https://fixed.invalid/v1",
+            "api_key": f"{FAKE_SECRET}-fixed",
+            "model": "model-fixed",
+            "protocol": "openai_chat",
+        })
+        with patch.object(
+            settings_service,
+            "effective_settings",
+            return_value={"llm": {
+                "mode": "pool",
+                "providers": [{
+                    "name": "global",
+                    "base_url": "https://global.invalid/v1",
+                    "api_key": f"{FAKE_SECRET}-global",
+                    "model": "model-global",
+                }],
+                "temperature": 0.3,
+                "base_url": "https://single.invalid/v1",
+                "api_key": f"{FAKE_SECRET}-single",
+                "model": "model-single",
+                "protocol": "auto",
+            }},
+        ):
+            providers = settings_service.resolve_llm_providers(task)
+
+        self.assertEqual(len(providers), 1)
+        self.assertEqual(providers[0].model, "model-fixed")
+
+    def test_explicit_fixed_single_without_overrides_does_not_fall_back_to_pool(self) -> None:
+        task = SimpleNamespace(model_config_json={"inherit_global": False})
+        with patch.object(
+            settings_service,
+            "effective_settings",
+            return_value={"llm": {
+                "mode": "pool",
+                "providers": [{
+                    "name": "global",
+                    "base_url": "https://global.invalid/v1",
+                    "api_key": f"{FAKE_SECRET}-global",
+                    "model": "model-global",
+                }],
+                "temperature": 0.3,
+                "base_url": "https://single.invalid/v1",
+                "api_key": f"{FAKE_SECRET}-single",
+                "model": "model-single",
+                "protocol": "openai_chat",
+            }},
+        ):
+            providers = settings_service.resolve_llm_providers(task)
+
+        self.assertEqual(len(providers), 1)
+        self.assertEqual(providers[0].model, "model-single")
+
+    def test_switching_task_back_to_global_clears_stale_override(self) -> None:
+        task = SimpleNamespace(
+            model_config_json={
+                "inherit_global": False,
+                "base_url": "https://fixed.invalid/v1",
+                "api_key": f"{FAKE_SECRET}-fixed",
+                "model": "model-fixed",
+                "protocol": "openai_chat",
+                "prompt_version": "modern",
+            },
+            fofa_query="",
+        )
+        session = SimpleNamespace(
+            get=AsyncMock(return_value=task),
+            commit=AsyncMock(),
+            refresh=AsyncMock(),
+        )
+        request = UpdateTaskRequest(model_config_data=PartialModelConfigDTO(inherit_global=True))
+
+        async def run_update():
+            with (
+                patch.object(tasks_api, "_compute_stats", new=AsyncMock(return_value=Mock())),
+                patch.object(tasks_api, "_task_to_dto", return_value={"ok": True}),
+            ):
+                return await tasks_api.update_task("task-1", request, session)
+
+        import asyncio
+        result = asyncio.run(run_update())
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(task.model_config_json, {
+            "prompt_version": "modern",
+            "inherit_global": True,
+        })
+
+    def test_editing_legacy_task_keeps_key_when_effective_protocol_is_unchanged(self) -> None:
+        task = SimpleNamespace(
+            model_config_json={
+                "inherit_global": False,
+                "base_url": "https://legacy.invalid/v1",
+                "api_key": f"{FAKE_SECRET}-legacy",
+                "model": "model-legacy",
+            },
+            fofa_query="",
+        )
+        session = SimpleNamespace(
+            get=AsyncMock(return_value=task),
+            commit=AsyncMock(),
+            refresh=AsyncMock(),
+        )
+        request = UpdateTaskRequest(model_config_data=PartialModelConfigDTO(
+            inherit_global=False,
+            base_url="https://legacy.invalid/v1",
+            model="model-legacy",
+            protocol="openai_chat",
+        ))
+        runtime_config = LLMConfig(
+            base_url="https://legacy.invalid/v1",
+            api_key=f"{FAKE_SECRET}-legacy",
+            model="model-legacy",
+            protocol="openai_chat",
+        )
+
+        async def run_update():
+            with (
+                patch.object(tasks_api, "resolve_llm_config", return_value=runtime_config),
+                patch.object(tasks_api, "_compute_stats", new=AsyncMock(return_value=Mock())),
+                patch.object(tasks_api, "_task_to_dto", return_value={"ok": True}),
+            ):
+                return await tasks_api.update_task("task-1", request, session)
+
+        import asyncio
+        result = asyncio.run(run_update())
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(task.model_config_json["api_key"], f"{FAKE_SECRET}-legacy")
+        self.assertEqual(task.model_config_json["protocol"], "openai_chat")
+
+    def test_legacy_create_payload_with_model_fields_keeps_fixed_single(self) -> None:
+        request = CreateTaskRequest(
+            name="legacy-client",
+            model_config_data=ModelConfigDTO(
+                base_url="https://legacy.invalid/v1",
+                api_key=f"{FAKE_SECRET}-legacy",
+                model="model-legacy",
+                protocol="openai_chat",
+            ),
+        )
+        session = SimpleNamespace(add=Mock(), commit=AsyncMock(), refresh=AsyncMock())
+
+        async def run_create():
+            with patch.object(tasks_api, "_task_to_dto", return_value={"ok": True}):
+                return await tasks_api.create_task(request, session)
+
+        import asyncio
+        result = asyncio.run(run_create())
+        created_task = session.add.call_args.args[0]
+
+        self.assertEqual(result, {"ok": True})
+        self.assertFalse(created_task.model_config_json["inherit_global"])
+        self.assertEqual(created_task.model_config_json["model"], "model-legacy")
+
+
+class ProviderHealthTests(StateResetMixin, unittest.TestCase):
+    def test_health_state_is_isolated_by_protocol(self) -> None:
+        base_url = "https://protocol.invalid/v1"
+        model = "model-protocol"
+        api_key = f"{FAKE_SECRET}-protocol"
+
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            health.mark_provider_failed(
+                base_url,
+                model,
+                "mock OpenAI protocol failure",
+                api_key,
+                "openai_chat",
+                kind="network",
+            )
+
+        self.assertNotEqual(
+            health.provider_ref(base_url, model, api_key, "openai_chat"),
+            health.provider_ref(base_url, model, api_key, "anthropic_messages"),
+        )
+        self.assertFalse(
+            health.acquire_provider_slot(
+                base_url, model, api_key, "openai_chat"
+            )[0]
+        )
+        self.assertEqual(
+            health.acquire_provider_slot(
+                base_url, model, api_key, "anthropic_messages"
+            ),
+            (True, "ready"),
+        )
+
+    def test_cooldown_allows_one_half_open_probe_then_recovers(self) -> None:
+        base_url = "https://health.invalid/v1"
+        model = "model-health"
+        api_key = f"{FAKE_SECRET}-health"
+        ref = health.provider_ref(base_url, model, api_key)
+
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            state = health.mark_provider_failed(
+                base_url, model, "mock transport failure", api_key, kind="network"
+            )
+            self.assertEqual(state["status"], "cooldown")
+            self.assertFalse(health.acquire_provider_slot(base_url, model, api_key)[0])
+
+            with health._LOCK:
+                health._HEALTH[ref]["cooldown_until_ts"] = 0
+
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key),
+                (True, "half_open"),
+            )
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key),
+                (False, "half_open_inflight"),
+            )
+
+            health.mark_provider_ok(base_url, model, api_key)
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key),
+                (True, "ready"),
+            )
+            self.assertEqual(health.snapshot()[ref]["status"], "ok")
+
+    def test_failed_provider_gets_one_half_open_probe_after_retry_delay(self) -> None:
+        base_url = "https://recover.invalid/v1"
+        model = "model-recover"
+        api_key = f"{FAKE_SECRET}-recover"
+        ref = health.provider_ref(base_url, model, api_key)
+
+        with patch.object(health, "_FAIL_THRESHOLD", 2):
+            health.mark_provider_failed(base_url, model, "mock failure", api_key, kind="network")
+            self.assertFalse(health.acquire_provider_slot(base_url, model, api_key, owner="a")[0])
+            with health._LOCK:
+                health._HEALTH[ref]["failed_retry_at_ts"] = 0
+
+            self.assertEqual(health.snapshot()[ref]["status"], "half_open")
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key, owner="a"),
+                (True, "half_open"),
+            )
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key, owner="b"),
+                (False, "half_open_inflight"),
+            )
+
+    def test_invalid_request_never_creates_global_health_failure(self) -> None:
+        base_url = "https://request-error.invalid/v1"
+        model = "model-request-error"
+        api_key = f"{FAKE_SECRET}-request-error"
+        ref = health.provider_ref(base_url, model, api_key)
+
+        for _ in range(10):
+            state = health.mark_provider_failed(
+                base_url,
+                model,
+                "mock request validation failure",
+                api_key,
+                kind="invalid_request",
+            )
+            self.assertEqual(state["status"], "ok")
+
+        self.assertNotIn(ref, health.snapshot())
+        self.assertEqual(
+            health.acquire_provider_slot(base_url, model, api_key, owner="worker-a"),
+            (True, "ready"),
+        )
+
+    def test_invalid_request_releases_half_open_probe_leases(self) -> None:
+        base_url = "https://request-probe.invalid/v1"
+        model = "model-request-probe"
+        api_key = f"{FAKE_SECRET}-request-probe"
+        ref = health.provider_ref(base_url, model, api_key)
+
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 2),
+            patch.object(health, "_BEHAVIOR_FAIL_THRESHOLD", 2),
+        ):
+            health.mark_provider_failed(
+                base_url, model, "mock transport failure", api_key, kind="network"
+            )
+            health.mark_provider_behavior_failed(
+                base_url, model, "mock behavior failure", api_key
+            )
+            with health._LOCK:
+                health._HEALTH[ref]["failed_retry_at_ts"] = 0
+                health._HEALTH[ref]["behavior_retry_at_ts"] = 0
+
+            self.assertEqual(health.snapshot()[ref]["status"], "half_open")
+            self.assertEqual(
+                health.acquire_provider_slot(
+                    base_url, model, api_key, owner="worker-a"
+                ),
+                (True, "half_open"),
+            )
+
+            state = health.mark_provider_failed(
+                base_url,
+                model,
+                "mock request validation failure",
+                api_key,
+                kind="invalid_request",
+            )
+            self.assertEqual(state["transition"], "request_rejected")
+            self.assertEqual(
+                health.acquire_provider_slot(
+                    base_url, model, api_key, owner="worker-b"
+                ),
+                (True, "half_open"),
+            )
+
+    def test_behavior_cooldown_probe_is_bound_to_one_worker(self) -> None:
+        base_url = "https://behavior.invalid/v1"
+        model = "model-behavior"
+        api_key = f"{FAKE_SECRET}-behavior"
+        ref = health.provider_ref(base_url, model, api_key)
+
+        with (
+            patch.object(health, "_BEHAVIOR_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            health.mark_provider_behavior_failed(
+                base_url, model, "mock empty tool loop", api_key
+            )
+            with health._LOCK:
+                health._HEALTH[ref]["behavior_cooldown_until_ts"] = 0
+
+            self.assertEqual(health.snapshot()[ref]["status"], "half_open")
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key, owner="worker-a"),
+                (True, "ready"),
+            )
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key, owner="worker-b"),
+                (False, "behavior_half_open_inflight"),
+            )
+            health.mark_provider_behavior_ok(base_url, model, api_key)
+            self.assertEqual(
+                health.acquire_provider_slot(base_url, model, api_key, owner="worker-b"),
+                (True, "ready"),
+            )
+
+
+class LLMClientPoolTests(StateResetMixin, unittest.TestCase):
+    def test_error_classification_covers_non_retryable_provider_failures(self) -> None:
+        cases = {
+            400: ("参数无效", "invalid_request"),
+            403: ("mock upstream response", "blocked"),
+            422: ("mock upstream response", "invalid_request"),
+        }
+        for status, (message, expected) in cases.items():
+            error = RuntimeError(message)
+            error.status_code = status
+            with self.subTest(status=status):
+                classified = client_module._classify_error(error)
+                self.assertEqual(classified.kind, expected)
+                self.assertTrue(client_module._should_try_next_provider(classified))
+
+        not_found = client_module.LLMError("unknown", "endpoint not found", status=404)
+        self.assertTrue(client_module._should_try_next_provider(not_found))
+
+    def test_auth_failure_does_not_retry_same_provider(self) -> None:
+        provider = _provider("auth-failure")
+        error = RuntimeError("invalid api key")
+        error.status_code = 401
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[provider])
+            llm.client.chat.completions.create.side_effect = error
+            with (
+                patch.object(client_module.time, "sleep") as sleep,
+                self.assertRaises(client_module.LLMError) as raised,
+            ):
+                llm._chat_current_provider([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "auth")
+        self.assertEqual(llm.client.chat.completions.create.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_weighted_round_robin_uses_configured_distribution(self) -> None:
+        primary = _provider("weighted-primary", weight=3)
+        secondary = _provider("weighted-secondary", weight=1)
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            first_models = [llm._provider_order()[0].model for _ in range(4)]
+
+        self.assertEqual(
+            first_models,
+            [primary.model, primary.model, secondary.model, primary.model],
+        )
+
+    def test_smooth_round_robin_keeps_duplicate_entries_independent(self) -> None:
+        primary = _provider("duplicate-provider")
+        duplicate = primary.model_copy()
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, duplicate])
+            selected = [llm._provider_order()[0] for _ in range(2)]
+
+        self.assertIs(selected[0], primary)
+        self.assertIs(selected[1], duplicate)
+
+    def test_pool_with_one_enabled_provider_keeps_single_provider_retries(self) -> None:
+        provider = _provider("single-enabled-provider")
+        expected = SimpleNamespace(content="ok", tool_calls=None)
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=expected)],
+            usage=None,
+        )
+        api_client = Mock()
+        api_client.chat.completions.create.side_effect = [
+            RuntimeError("network connection failed"),
+            response,
+        ]
+
+        with (
+            patch.object(client_module.LLMClient, "_build_client", return_value=api_client),
+            patch.object(client_module.time, "sleep"),
+        ):
+            llm = client_module.LLMClient(providers=[provider], pool_mode=True)
+            result = llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertFalse(llm.pool_mode)
+        self.assertIs(result, expected)
+        self.assertEqual(api_client.chat.completions.create.call_count, 2)
+
+    def test_sticky_provider_does_not_advance_weighted_round_robin(self) -> None:
+        primary = _provider("sticky-weighted-primary", weight=3)
+        secondary = _provider("sticky-weighted-secondary")
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            llm._provider_order()
+            with client_module._RR_LOCK:
+                before = dict(client_module._RR_STATE)
+            llm._sticky_provider_ref = health.provider_ref(
+                primary.base_url,
+                primary.model,
+                primary.api_key,
+                primary.protocol,
+            )
+
+            for _ in range(8):
+                self.assertIs(llm._provider_order()[0], primary)
+
+            with client_module._RR_LOCK:
+                after = dict(client_module._RR_STATE)
+
+        self.assertEqual(after, before)
+
+    def test_single_provider_cooldown_raises_structured_retry(self) -> None:
+        provider = _provider("single-cooldown")
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            health.mark_provider_failed(
+                provider.base_url,
+                provider.model,
+                "mock provider failure",
+                provider.api_key,
+                provider.protocol,
+                kind="network",
+            )
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[provider], pool_mode=False)
+            with (
+                patch.object(llm, "_chat_current_provider") as invoke,
+                self.assertRaises(client_module.LLMError) as raised,
+            ):
+                llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "provider_cooldown")
+        self.assertGreaterEqual(raised.exception.retry_after, 1)
+        invoke.assert_not_called()
+
+    def test_single_provider_failure_that_starts_cooldown_returns_structured_retry(self) -> None:
+        provider = _provider("single-starts-cooldown")
+        failure = client_module.LLMError("network", "mock provider failure")
+
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+            patch.object(client_module.LLMClient, "_build_client", return_value=Mock()),
+        ):
+            llm = client_module.LLMClient(providers=[provider], pool_mode=False)
+            with (
+                patch.object(llm, "_chat_current_provider", side_effect=failure),
+                self.assertRaises(client_module.LLMError) as raised,
+            ):
+                llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "provider_cooldown")
+        self.assertGreaterEqual(raised.exception.retry_after, 1)
+
+    def test_failed_provider_falls_through_to_next_provider(self) -> None:
+        primary = _provider("failover-primary")
+        secondary = _provider("failover-secondary")
+        expected = object()
+        first_error = client_module.LLMError("network", "mock first endpoint failure")
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            with (
+                patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+                patch.object(
+                    llm,
+                    "_chat_current_provider",
+                    side_effect=[first_error, expected],
+                ) as invoke
+            ):
+                result = llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertIs(result, expected)
+        self.assertEqual(invoke.call_count, 2)
+        self.assertEqual(llm.config.model, secondary.model)
+
+    def test_all_quota_failures_preserve_quota_error(self) -> None:
+        primary = _provider("quota-primary")
+        secondary = _provider("quota-secondary")
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            with (
+                patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+                patch.object(
+                    llm,
+                    "_chat_current_provider",
+                    side_effect=[
+                        client_module.LLMError("quota", "primary quota exhausted"),
+                        client_module.LLMError("quota", "secondary quota exhausted"),
+                    ],
+                ),
+                self.assertRaises(client_module.LLMError) as raised,
+            ):
+                llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "quota")
+
+    def test_actual_error_is_preserved_when_other_provider_is_cooling(self) -> None:
+        primary = _provider("actual-auth-error")
+        secondary = _provider("already-cooling")
+        auth_error = client_module.LLMError("auth", "invalid test credential")
+
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            health.mark_provider_failed(
+                secondary.base_url,
+                secondary.model,
+                "mock endpoint outage",
+                secondary.api_key,
+                secondary.protocol,
+                kind="network",
+            )
+
+            with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+                llm = client_module.LLMClient(providers=[primary, secondary])
+                with (
+                    patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+                    patch.object(
+                        llm,
+                        "_chat_current_provider",
+                        side_effect=auth_error,
+                    ) as invoke,
+                    self.assertRaises(client_module.LLMError) as raised,
+                ):
+                    llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "auth")
+        invoke.assert_called_once()
+
+    def test_invalid_request_failover_does_not_poison_global_health(self) -> None:
+        primary = _provider("invalid-request-primary")
+        secondary = _provider("invalid-request-secondary")
+        expected = object()
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            with (
+                patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+                patch.object(
+                    llm,
+                    "_chat_current_provider",
+                    side_effect=[
+                        client_module.LLMError(
+                            "invalid_request",
+                            "request rejected",
+                            status=400,
+                        ),
+                        expected,
+                    ],
+                ),
+            ):
+                self.assertIs(
+                    llm.chat([{"role": "user", "content": "mock request"}]),
+                    expected,
+                )
+
+        ref = health.provider_ref(
+            primary.base_url,
+            primary.model,
+            primary.api_key,
+            primary.protocol,
+        )
+        snapshot = health.snapshot()
+        state = snapshot.get(ref, {})
+        self.assertNotIn(ref, snapshot)
+        self.assertNotIn(state.get("status"), {"failed", "cooldown"})
+        self.assertEqual(int(state.get("consecutive_failures") or 0), 0)
+
+    def test_selection_callback_reports_each_attempted_provider(self) -> None:
+        primary = _provider("selection-primary")
+        secondary = _provider("selection-secondary")
+        selections = []
+        first_error = client_module.LLMError("network", "mock first endpoint failure")
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(
+                providers=[primary, secondary],
+                on_provider_selected=selections.append,
+            )
+            with (
+                patch.object(llm, "_provider_order", return_value=[primary, secondary]),
+                patch.object(
+                    llm,
+                    "_chat_current_provider",
+                    side_effect=[first_error, object()],
+                ),
+            ):
+                llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(
+            [item["model"] for item in selections],
+            [primary.model, secondary.model],
+        )
+        self.assertIs(llm.selected_provider, secondary)
+
+    def test_successful_provider_stays_sticky_for_worker_session(self) -> None:
+        primary = _provider("sticky-primary")
+        secondary = _provider("sticky-secondary")
+        seen_models = []
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+
+            def invoke(*_args, **_kwargs):
+                seen_models.append(llm.config.model)
+                return object()
+
+            with patch.object(llm, "_chat_current_provider", side_effect=invoke):
+                llm.chat([{"role": "user", "content": "first"}])
+                llm.chat([{"role": "user", "content": "second"}])
+
+        self.assertEqual(seen_models, [primary.model, primary.model])
+
+    def test_pool_mode_does_not_retry_bad_endpoint_before_failover(self) -> None:
+        primary = _provider("fast-primary")
+        secondary = _provider("fast-secondary")
+        first_client = Mock()
+        second_client = Mock()
+        first_client.chat.completions.create.side_effect = client_module.LLMError(
+            "network", "primary unavailable"
+        )
+        second_client.chat.completions.create.side_effect = client_module.LLMError(
+            "network", "secondary unavailable"
+        )
+
+        with (
+            patch.object(
+                client_module.LLMClient,
+                "_build_client",
+                side_effect=[first_client, second_client],
+            ),
+            patch.object(client_module.time, "sleep") as sleep,
+        ):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            with self.assertRaises(client_module.LLMError):
+                llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(first_client.chat.completions.create.call_count, 1)
+        self.assertEqual(second_client.chat.completions.create.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_all_cooling_providers_return_retry_delay_without_calling_network(self) -> None:
+        providers = [_provider("cooldown-a"), _provider("cooldown-b")]
+        with (
+            patch.object(health, "_FAIL_THRESHOLD", 1),
+            patch.object(health, "_COOLDOWN_STEPS", [60]),
+        ):
+            for provider in providers:
+                health.mark_provider_failed(
+                    provider.base_url,
+                    provider.model,
+                    "mock cooldown failure",
+                    provider.api_key,
+                    provider.protocol,
+                    kind="network",
+                )
+
+            with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+                llm = client_module.LLMClient(providers=providers)
+                with patch.object(llm, "_chat_current_provider") as invoke:
+                    with self.assertRaises(client_module.LLMError) as raised:
+                        llm.chat([{"role": "user", "content": "mock request"}])
+
+        self.assertEqual(raised.exception.kind, "provider_cooldown")
+        self.assertGreaterEqual(raised.exception.retry_after, 1)
+        invoke.assert_not_called()
+
+    def test_tls_downgrade_is_remembered_only_for_affected_provider(self) -> None:
+        primary = _provider("tls-primary")
+        secondary = _provider("tls-secondary")
+
+        with patch.object(client_module.LLMClient, "_build_client", return_value=Mock()):
+            llm = client_module.LLMClient(providers=[primary, secondary])
+            self.assertTrue(llm._maybe_downgrade_tls(Exception("certificate verify failed")))
+            self.assertTrue(llm._insecure_tls)
+
+            llm._activate_provider(secondary)
+            self.assertFalse(llm._insecure_tls)
+
+            llm._activate_provider(primary)
+            self.assertTrue(llm._insecure_tls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_model_probe.py
+++ b/tests/test_task_model_probe.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_DOTENV = PROJECT_ROOT / ".env"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_path_exists = Path.exists
+_path_read_text = Path.read_text
+
+
+def _is_project_dotenv(path: Path) -> bool:
+    return os.path.normcase(os.path.abspath(path)) == os.path.normcase(str(PROJECT_DOTENV))
+
+
+def _exists_without_project_dotenv(path: Path) -> bool:
+    return False if _is_project_dotenv(path) else _path_exists(path)
+
+
+def _read_text_without_project_dotenv(path: Path, *args, **kwargs) -> str:
+    if _is_project_dotenv(path):
+        raise AssertionError("Tests must not read the project .env file")
+    return _path_read_text(path, *args, **kwargs)
+
+
+with (
+    patch.object(Path, "exists", _exists_without_project_dotenv),
+    patch.object(Path, "read_text", _read_text_without_project_dotenv),
+):
+    from app.api import tasks as tasks_api
+    from app.config import LLMConfig
+
+
+FAKE_SECRET = "task-key-not-a-real-secret"
+TASK_BASE_URL = "https://task-model.invalid/v1"
+
+
+def _task() -> SimpleNamespace:
+    return SimpleNamespace(model_config_json={
+        "inherit_global": False,
+        "base_url": TASK_BASE_URL,
+        "api_key": FAKE_SECRET,
+        "model": "task-model",
+        "protocol": "openai_chat",
+    })
+
+
+def _task_config() -> LLMConfig:
+    return LLMConfig(
+        base_url=TASK_BASE_URL,
+        api_key=FAKE_SECRET,
+        model="task-model",
+        protocol="openai_chat",
+    )
+
+
+class TaskModelProbeTests(unittest.TestCase):
+    def test_public_task_config_returns_reference_without_plaintext_key(self) -> None:
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "resolve_llm_providers", return_value=[_task_config()]),
+            patch.object(tasks_api, "resolve_worker_prompt_version", return_value="legacy"),
+        ):
+            public = tasks_api._public_model_config(_task())
+
+        self.assertEqual(public["key_ref"], tasks_api.secret_ref(FAKE_SECRET))
+        self.assertNotIn(FAKE_SECRET, json.dumps(public))
+
+    def test_task_probe_reuses_saved_key_only_for_matching_endpoint(self) -> None:
+        session = SimpleNamespace(get=AsyncMock(return_value=_task()))
+        probe = AsyncMock(return_value={"ok": True, "models": ["task-model"]})
+        body = tasks_api.TaskModelsProbeRequest(
+            base_url=f"{TASK_BASE_URL}/",
+            key_ref=tasks_api.secret_ref(FAKE_SECRET),
+            protocol="openai_chat",
+        )
+
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "list_available_models", probe),
+        ):
+            result = asyncio.run(tasks_api.probe_task_models("task-1", body, session))
+
+        self.assertTrue(result["ok"])
+        probe.assert_awaited_once_with(
+            base_url=f"{TASK_BASE_URL}/",
+            api_key=FAKE_SECRET,
+            protocol="openai_chat",
+        )
+
+    def test_task_probe_does_not_send_saved_key_to_changed_endpoint(self) -> None:
+        session = SimpleNamespace(get=AsyncMock(return_value=_task()))
+        probe = AsyncMock()
+        body = tasks_api.TaskModelsProbeRequest(
+            base_url="https://changed.invalid/v1",
+            key_ref=tasks_api.secret_ref(FAKE_SECRET),
+            protocol="openai_chat",
+        )
+
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "list_available_models", probe),
+        ):
+            result = asyncio.run(tasks_api.probe_task_models("task-1", body, session))
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["models"], [])
+        probe.assert_not_awaited()
+
+    def test_task_probe_does_not_send_saved_key_to_changed_protocol(self) -> None:
+        session = SimpleNamespace(get=AsyncMock(return_value=_task()))
+        probe = AsyncMock()
+        body = tasks_api.TaskModelsProbeRequest(
+            base_url=TASK_BASE_URL,
+            key_ref=tasks_api.secret_ref(FAKE_SECRET),
+            protocol="anthropic_messages",
+        )
+
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "list_available_models", probe),
+        ):
+            result = asyncio.run(tasks_api.probe_task_models("task-1", body, session))
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["models"], [])
+        probe.assert_not_awaited()
+
+    def test_task_probe_without_base_uses_bound_task_endpoint(self) -> None:
+        session = SimpleNamespace(get=AsyncMock(return_value=_task()))
+        probe = AsyncMock(return_value={"ok": True, "models": ["task-model"]})
+        body = tasks_api.TaskModelsProbeRequest(
+            key_ref=tasks_api.secret_ref(FAKE_SECRET),
+            protocol="openai_chat",
+        )
+
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "list_available_models", probe),
+        ):
+            result = asyncio.run(tasks_api.probe_task_models("task-1", body, session))
+
+        self.assertTrue(result["ok"])
+        probe.assert_awaited_once_with(
+            base_url=TASK_BASE_URL,
+            api_key=FAKE_SECRET,
+            protocol="openai_chat",
+        )
+
+    def test_task_probe_without_protocol_uses_bound_task_protocol(self) -> None:
+        session = SimpleNamespace(get=AsyncMock(return_value=_task()))
+        probe = AsyncMock(return_value={"ok": True, "models": ["task-model"]})
+        body = tasks_api.TaskModelsProbeRequest(
+            key_ref=tasks_api.secret_ref(FAKE_SECRET),
+        )
+
+        with (
+            patch.object(tasks_api, "resolve_llm_config", return_value=_task_config()),
+            patch.object(tasks_api, "list_available_models", probe),
+        ):
+            result = asyncio.run(tasks_api.probe_task_models("task-1", body, session))
+
+        self.assertTrue(result["ok"])
+        probe.assert_awaited_once_with(
+            base_url=TASK_BASE_URL,
+            api_key=FAKE_SECRET,
+            protocol="openai_chat",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
支持单端点与端点池二选一

1. 支持端点权重、启停、协议、模型查询和连接测试
2. 任务可跟随系统模型方案，也可使用独立模型配置
3. 使用平滑加权轮询分配端点
4. Worker 在任务期间保持端点粘性
5. 支持端点健康状态、分级冷却、半开探测和池内故障切换
6. Worker Matrix 展示实际使用的模型与端点
<img width="774" height="529" alt="image" src="https://github.com/user-attachments/assets/205d5358-e9d2-4a38-8c7d-a8a4fcaf6b0e" />
<img width="1253" height="708" alt="image" src="https://github.com/user-attachments/assets/575a2efe-dcfb-4bd6-bbb8-a5160af768ea" />
