### PR TITLE
feat: 提升 Agent 可见性与运行中可控性

### DIFF
--- a/app/agents/worker.py
+++ b/app/agents/worker.py
@@ -64,6 +64,7 @@ class Worker:
         fofa_key: str = "",
         fofa_base_url: str = "",
         prompt_version: str | None = None,
+        pop_directive: Optional[Callable[[], Optional[str]]] = None,
     ):
         self.target = target
         self.llm = llm or LLMClient()
@@ -80,6 +81,8 @@ class Worker:
         self._finished: Optional[dict] = None
         # 审核打回的定向深挖任务：{directive, vuln_type, original_title, original_summary}
         self.deepen_context = deepen_context or None
+        # 人工 mid-run 指令：编排层按轮次弹出一条，注入下一轮 user 消息。
+        self.pop_directive = pop_directive
         # 资产情报：候选归属学校/org/title，供 worker 核实并写进报告 owner
         self.target_meta = target_meta or {}
         # 同一 target 历史已提交漏洞摘要，用于 worker 提交前查重（superseded 不传入）
@@ -258,6 +261,25 @@ class Worker:
         while rounds < max_rounds:
             if self.cancel_event.is_set():
                 return self._cancelled_result(rounds)
+            # 人工实时指令：在开新一轮 LLM 前注入，优先于自主打法。
+            # 用 getattr：部分单测用 Worker.__new__ 绕过 __init__。
+            directive = ""
+            pop_directive = getattr(self, "pop_directive", None)
+            if pop_directive:
+                try:
+                    directive = (pop_directive() or "").strip()
+                except Exception:
+                    directive = ""
+            if directive:
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "# 人工实时指令（优先执行）\n"
+                        f"{directive}\n\n"
+                        "请按上述指令调整本轮打法，继续调用工具验证或 finish。"
+                    ),
+                })
+                self._emit("worker_directive", round=rounds + 1, text=directive[:500])
             rounds += 1
             try:
                 self._emit("llm_round_start", round=rounds)

--- a/app/api/dto.py
+++ b/app/api/dto.py
@@ -107,6 +107,11 @@ class UpdateTaskRequest(BaseModel):
     concurrency: Optional[int] = None
 
 
+class DirectiveRequest(BaseModel):
+    """向运行中 worker 注入的人工实时指令。"""
+    directive: str = Field(..., min_length=1, max_length=2000)
+
+
 class TaskStats(BaseModel):
     queued: int = 0
     scanning: int = 0

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dto import (
     CreateTaskRequest,
+    DirectiveRequest,
     TaskModelsProbeRequest,
     TaskResponse,
     TaskStats,
@@ -49,15 +50,33 @@ _STREAM_IMPORTANT_KINDS = frozenset({
     "reclaim", "recover", "workers_cancelled", "quota_stop",
     "killsweep_done", "killsweep_dedup", "killsweep_error", "killsweep_cancelled",
     "auth_status",
+    "escalate_done", "escalate_skip", "escalate_cancelled", "escalate_start",
+    "worker_directive_queued", "worker_directive",
+})
+# Verbose / Worker Trace：细粒度事件（默认活动流不回放，verbose 或 trace API 才返回）。
+_STREAM_TRACE_KINDS = frozenset({
+    "worker_start", "worker_finish", "worker_cancelled", "worker_auto_finish",
+    "worker_thought", "worker_directive", "worker_resume",
+    "tool_http", "tool_shell", "tool_shell_blocked", "tool_arg_error",
+    "tool_exception", "tool_js_analyze", "tool_decode", "tool_waf_advice",
+    "tool_fofa_lookup", "tool_session_set",
+    "llm_round_start", "llm_error", "llm_soft_retry", "llm_interrupt",
+    "finding_submitted", "finding_duplicate", "finding_invalid",
+    "auth_status", "finish_blocked",
+    "escalate_http", "escalate_shell", "escalate_session", "escalate_error", "escalate_abandon",
 })
 
 
-def _stream_event_visible(kind: str, level: str) -> bool:
+def _stream_event_visible(kind: str, level: str, *, verbose: bool = False) -> bool:
     if kind in _STREAM_NOISE_KINDS:
         return False
     if level in ("warn", "error"):
         return True
-    return kind in _STREAM_IMPORTANT_KINDS or kind == "error"
+    if kind in _STREAM_IMPORTANT_KINDS or kind == "error":
+        return True
+    if verbose and kind in _STREAM_TRACE_KINDS:
+        return True
+    return False
 
 
 def _is_observer(request: Request | None) -> bool:
@@ -729,7 +748,12 @@ async def _compute_site_collab(session: AsyncSession, task_id: str) -> dict | No
 
 
 @router.get("/{task_id}/board")
-async def task_board(task_id: str, request: Request, session: AsyncSession = Depends(get_session)):
+async def task_board(
+    task_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    verbose: bool = Query(False),
+):
     """实时看板快照：在跑 worker 活态 + 目标进度 + 最近事件（用于刷新后恢复）。"""
     from app.db.models import TaskEvent
     task = await session.get(Task, task_id)
@@ -739,6 +763,7 @@ async def task_board(task_id: str, request: Request, session: AsyncSession = Dep
     runner = manager.get_runner(task_id)
     observer = _is_observer(request)
     live = runner.live_workers() if runner else []
+    live_escalations = runner.live_escalations() if runner else []
     if observer:
         safe_live = []
         for w in live:
@@ -759,24 +784,38 @@ async def task_board(task_id: str, request: Request, session: AsyncSession = Dep
                 "mode": w.get("mode", ""),
             })
         live = safe_live
+        live_escalations = [{
+            "finding_id": e.get("finding_id", ""),
+            "title": "hidden",
+            "severity": e.get("severity", ""),
+            "action": "扩大危害进行中",
+            "started_at": e.get("started_at", ""),
+        } for e in live_escalations]
 
     stats = await _compute_stats(session, task_id)
 
     # 最近重要事件（倒序，给前端做历史回放；多取一些再过滤噪音）
+    fetch_limit = 500 if verbose else 200
+    event_cap = 120 if verbose else 60
     ev_rows = (await session.execute(
         select(TaskEvent).where(TaskEvent.task_id == task_id)
-        .order_by(TaskEvent.id.desc()).limit(200)
+        .order_by(TaskEvent.id.desc()).limit(fetch_limit)
     )).scalars().all()
     events = []
     for e in ev_rows:
-        if not _stream_event_visible(e.kind or "", e.level or "info"):
+        if not _stream_event_visible(e.kind or "", e.level or "info", verbose=verbose):
             continue
+        payload = e.payload or {}
         events.append({
             "agent": e.agent, "kind": e.kind, "level": e.level,
             "message": "" if observer else e.message,
             "ts": to_cst_iso(e.ts),
+            "target_id": "" if observer else (payload.get("target_id") or ""),
+            **({} if observer else {k: payload.get(k) for k in (
+                "url", "method", "command", "text", "title", "verdict", "round", "tool", "error"
+            ) if k in payload}),
         })
-        if len(events) >= 60:
+        if len(events) >= event_cap:
             break
 
     # 单站协作态势（仅 site 任务）：三阶段路线流水线，不含敏感数据，观察者也可看。
@@ -787,6 +826,7 @@ async def task_board(task_id: str, request: Request, session: AsyncSession = Dep
     return {
         "task_status": task.status,
         "live_workers": live,
+        "live_escalations": live_escalations,
         "stats": stats.model_dump(),
         "fofa_config": _observer_fofa_config() if observer else _public_fofa_config(task),
         "model_config_data": _observer_model_config() if observer else _public_model_config(task),
@@ -803,6 +843,72 @@ async def skip_target(task_id: str, target_id: str):
     res = await manager.skip_target(task_id, target_id)
     if not res.get("ok"):
         raise HTTPException(404, res.get("error") or "无法删除该目标")
+    return res
+
+
+@router.post("/{task_id}/targets/{target_id}/directive")
+async def inject_target_directive(task_id: str, target_id: str, body: DirectiveRequest):
+    """向运行中的 worker 注入人工实时指令；下一轮 LLM 调用前生效。"""
+    res = manager.inject_directive(task_id, target_id, body.directive)
+    if not res.get("ok"):
+        raise HTTPException(400, res.get("error") or "无法注入指令")
+    return res
+
+
+@router.get("/{task_id}/targets/{target_id}/trace")
+async def target_trace(
+    task_id: str,
+    target_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    limit: int = Query(200, ge=1, le=500),
+):
+    """单个目标的 worker 执行轨迹（落库的细粒度事件，刷新后可回看）。"""
+    if _is_observer(request):
+        raise HTTPException(403, "观摩令牌不允许查看执行轨迹")
+    tgt = await session.get(Target, target_id)
+    if not tgt or tgt.task_id != task_id:
+        raise HTTPException(404, "目标不存在或不属于该任务")
+    rows = (await session.execute(
+        select(TaskEvent)
+        .where(TaskEvent.task_id == task_id, TaskEvent.agent == "worker")
+        .order_by(TaskEvent.id.desc())
+        .limit(min(limit * 3, 1500))
+    )).scalars().all()
+    events = []
+    for e in rows:
+        payload = e.payload or {}
+        if payload.get("target_id") != target_id:
+            continue
+        events.append({
+            "agent": e.agent,
+            "kind": e.kind,
+            "level": e.level,
+            "message": e.message,
+            "ts": to_cst_iso(e.ts),
+            "target_id": target_id,
+            **{k: payload.get(k) for k in (
+                "url", "method", "command", "text", "title", "verdict", "round", "tool", "error"
+            ) if k in payload},
+        })
+        if len(events) >= limit:
+            break
+    events.reverse()  # 时间正序，便于 round-by-round 阅读
+    return {
+        "target_id": target_id,
+        "host": tgt.host or "",
+        "url": tgt.url or "",
+        "status": tgt.status,
+        "events": events,
+    }
+
+
+@router.post("/{task_id}/escalations/{finding_id}/cancel")
+async def cancel_escalation(task_id: str, finding_id: str):
+    """取消单个正在进行的扩大危害任务。"""
+    res = manager.cancel_escalation(task_id, finding_id)
+    if not res.get("ok"):
+        raise HTTPException(404, res.get("error") or "无法取消扩大危害")
     return res
 
 

--- a/app/events.py
+++ b/app/events.py
@@ -29,7 +29,15 @@ class EventBus:
             try:
                 q.put_nowait(event)
             except asyncio.QueueFull:
-                pass  # 慢消费者丢弃，不阻塞
+                # 慢消费者：丢掉最旧事件再塞入最新，避免静默整段失联。
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    continue
+                try:
+                    q.put_nowait(event)
+                except asyncio.QueueFull:
+                    pass
 
 
 bus = EventBus()

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -92,6 +92,18 @@ def _escalation_is_significant(orig_severity: str, res: dict) -> bool:
 LOOP_INTERVAL = 3.0
 LOW_WATERMARK = 5
 MAX_RETRY = 1  # 单 target 最多再挖 1 次
+# Worker 细粒度轨迹：落库供刷新回看（payload 已截断，避免 DB 膨胀）。
+_WORKER_TRACE_KINDS = frozenset({
+    "worker_start", "worker_finish", "worker_cancelled", "worker_auto_finish",
+    "worker_thought", "worker_directive", "worker_resume",
+    "tool_http", "tool_shell", "tool_shell_blocked", "tool_arg_error",
+    "tool_exception", "tool_js_analyze", "tool_decode", "tool_waf_advice",
+    "tool_fofa_lookup", "tool_session_set",
+    "llm_round_start", "llm_error", "llm_soft_retry", "llm_interrupt",
+    "finding_submitted", "finding_duplicate", "finding_invalid",
+    "auth_status", "finish_blocked",
+})
+_TRACE_TEXT_KEYS = ("text", "command", "url", "error", "message", "reason", "query", "summary")
 # 单 target 超时兜底。
 # WORKER_WALL_TIMEOUT 保持向后兼容：现在作为「无活动空闲超时」默认值。
 # 活跃 worker 可继续运行到 WORKER_MAX_WALL_TIMEOUT，避免深挖正在推进时被 30min 一刀切。
@@ -345,9 +357,14 @@ class TaskRunner:
         self._escalation_inflight: set[str] = set()  # 正在做扩大危害深挖的 finding_id
         self._escalation_tasks: dict[str, asyncio.Task] = {}
         self._escalation_cancel_events: dict[str, threading.Event] = {}
+        # 扩大危害活态（看板展示）
+        self._live_escalations: dict[str, dict] = {}
         # 实时看板：每个在跑 worker 的活态 {target_id: {host, url, round, action, started_at, findings}}
         self._live: dict[str, dict] = {}
         self._worker_last_activity: dict[str, float] = {}
+        # 人工 mid-run 指令队列：target_id → [directive, ...]（线程安全）
+        self._worker_directives: dict[str, list[str]] = {}
+        self._worker_directive_lock = threading.Lock()
         # 临时 LLM 错误回队计数（内存级，不耗 retry_count）：防止模型持续抽风时目标无限回队。
         self._transient_llm_requeue: dict[str, int] = {}
         # 企业模式缓存：企业目标多为用户指定的具体资产，不做同款簇冷却/限流
@@ -365,6 +382,117 @@ class TaskRunner:
 
     def live_workers(self) -> list[dict]:
         return list(self._live.values())
+
+    def live_escalations(self) -> list[dict]:
+        return list(self._live_escalations.values())
+
+    def inject_directive(self, target_id: str, directive: str) -> dict:
+        """向运行中的 worker 注入人工实时指令，下一轮 LLM 前生效。"""
+        text = (directive or "").strip()
+        if not text:
+            return {"ok": False, "error": "指令不能为空"}
+        if target_id not in self._active_workers:
+            return {"ok": False, "error": "该目标当前没有运行中的 worker"}
+        text = text[:2000]
+        with self._worker_directive_lock:
+            self._worker_directives.setdefault(target_id, []).append(text)
+        live = self._live.get(target_id) or {}
+        host = live.get("host") or target_id
+        try:
+            asyncio.get_running_loop().create_task(bus.publish(self.task_id, {
+                "agent": "orchestrator",
+                "kind": "worker_directive_queued",
+                "target_id": target_id,
+                "host": host,
+                "text": text[:300],
+                "message": f"已向 {host} 排队人工指令（下一轮生效）",
+                "ts": _now_iso(),
+            }))
+        except RuntimeError:
+            pass
+        return {"ok": True, "target_id": target_id, "host": host, "queued": True}
+
+    def _pop_directive(self, target_id: str) -> str | None:
+        with self._worker_directive_lock:
+            q = self._worker_directives.get(target_id) or []
+            if not q:
+                return None
+            text = q.pop(0)
+            if not q:
+                self._worker_directives.pop(target_id, None)
+            return text
+
+    def cancel_escalation(self, finding_id: str, reason: str = "用户取消扩大危害") -> dict:
+        """取消单个正在进行的扩大危害任务。"""
+        if finding_id not in self._escalation_inflight and finding_id not in self._escalation_tasks:
+            return {"ok": False, "error": "该洞当前没有进行中的扩大危害"}
+        if ev := self._escalation_cancel_events.get(finding_id):
+            ev.set()
+        if t := self._escalation_tasks.get(finding_id):
+            t.cancel()
+        live = self._live_escalations.pop(finding_id, None) or {}
+        title = live.get("title") or finding_id
+        try:
+            asyncio.get_running_loop().create_task(bus.publish(self.task_id, {
+                "agent": "escalation",
+                "kind": "escalate_cancelled",
+                "finding_id": finding_id,
+                "message": f"扩大危害已取消：{title}",
+                "reason": reason,
+                "ts": _now_iso(),
+            }))
+        except RuntimeError:
+            pass
+        return {"ok": True, "finding_id": finding_id, "title": title}
+
+    @staticmethod
+    def _truncate_trace_payload(payload: dict) -> dict:
+        out: dict = {}
+        for k, v in (payload or {}).items():
+            if k in ("finding",):
+                continue
+            if k in _TRACE_TEXT_KEYS and isinstance(v, str):
+                out[k] = v[:500]
+            elif isinstance(v, str) and len(v) > 300:
+                out[k] = v[:300]
+            elif isinstance(v, (str, int, float, bool)) or v is None:
+                out[k] = v
+            elif isinstance(v, list) and len(v) <= 8:
+                out[k] = v
+            elif isinstance(v, dict) and len(v) <= 12:
+                out[k] = {sk: (sv[:200] if isinstance(sv, str) and len(sv) > 200 else sv)
+                          for sk, sv in list(v.items())[:12]
+                          if isinstance(sv, (str, int, float, bool, type(None)))}
+        return out
+
+    async def _persist_worker_trace(self, task_id: str, target_id: str, kind: str, payload: dict) -> None:
+        """选择性落库 worker 细粒度事件，刷新后可回看。"""
+        if kind not in _WORKER_TRACE_KINDS:
+            return
+        safe = self._truncate_trace_payload(payload)
+        msg = ""
+        if kind == "worker_thought":
+            msg = (safe.get("text") or "")[:300]
+        elif kind == "tool_http":
+            msg = f"{safe.get('method', 'GET')} {safe.get('url', '')}"[:300]
+        elif kind == "tool_shell":
+            msg = f"$ {safe.get('command', '')}"[:300]
+        elif kind == "worker_directive":
+            msg = f"人工指令: {(safe.get('text') or '')[:200]}"
+        elif kind in ("llm_error", "tool_exception", "tool_arg_error"):
+            msg = str(safe.get("error") or safe.get("message") or kind)[:300]
+        else:
+            msg = str(safe.get("message") or kind)[:200]
+        try:
+            async with SessionLocal() as session:
+                session.add(TaskEvent(
+                    task_id=task_id, agent="worker", kind=kind, level="info",
+                    message=msg,
+                    payload={"target_id": target_id, **safe},
+                ))
+                await session.commit()
+        except Exception:
+            logger.debug("persist worker trace failed task=%s kind=%s", task_id[:8], kind, exc_info=True)
 
     def diagnostic_snapshot(self) -> dict:
         return {
@@ -1175,6 +1303,7 @@ class TaskRunner:
         self._escalation_tasks.clear()
         self._escalation_inflight.clear()
         self._escalation_cancel_events.clear()
+        self._live_escalations.clear()
 
     def _queue_or_dead_after_attempt(self, tgt: Target, reason: str) -> bool:
         """失败/恢复后的统一回队策略。返回 True=回队，False=终态 dead。
@@ -1611,6 +1740,8 @@ class TaskRunner:
                 st["action"] = f"工具异常: {data.get('tool','')}"
             elif kind == "worker_thought":
                 st["action"] = "💭 " + (data.get("text") or "")[:120]
+            elif kind == "worker_directive":
+                st["action"] = "🎛 执行人工指令: " + (data.get("text") or "")[:100]
             elif kind == "llm_round_start":
                 st["action"] = "LLM 思考中…"
             elif kind == "llm_error":
@@ -1667,6 +1798,11 @@ class TaskRunner:
                     if kind == "auth_status":
                         at = asyncio.create_task(self._persist_auth_status(target_id, dict(payload)))
                         at.add_done_callback(lambda f: _log_bg_task_exc(f, "persist_auth_status"))
+                    if kind in _WORKER_TRACE_KINDS:
+                        tr = asyncio.create_task(
+                            self._persist_worker_trace(task_id, target_id, kind, dict(payload))
+                        )
+                        tr.add_done_callback(lambda f: _log_bg_task_exc(f, "persist_worker_trace"))
                     _update_live(kind, payload)
                     pt = asyncio.create_task(bus.publish(
                         task_id, {"agent": "worker", "kind": kind, "target_id": target_id, **payload}))
@@ -1778,7 +1914,8 @@ class TaskRunner:
                             duplicate_history=duplicate_history,
                             cancel_event=cancel_event, src_type=src_type,
                             fofa_key=fofa_key, fofa_base_url=fofa_base_url,
-                            prompt_version=prompt_version)
+                            prompt_version=prompt_version,
+                            pop_directive=lambda: self._pop_directive(target_id))
             worker_holder["worker"] = worker
             try:
                 return worker.run().model_dump(mode="json")
@@ -1788,6 +1925,8 @@ class TaskRunner:
                 #  导致每个正常完成的 worker 都被下方 externally_cancelled 判定误判为"被取消"而丢弃结果，
                 #  findings/done 永远为 0、出洞概率暴跌。）
                 worker.executor.kill_processes()
+                with self._worker_directive_lock:
+                    self._worker_directives.pop(target_id, None)
 
         cancelled = False
         # 区分「超时」与「外部取消(pause/stop/reclaim)」：两者都会 set cancel_event(通知
@@ -3036,6 +3175,7 @@ class TaskRunner:
             self._escalation_inflight.discard(finding_id)
             self._escalation_tasks.pop(finding_id, None)
             self._escalation_cancel_events.pop(finding_id, None)
+            self._live_escalations.pop(finding_id, None)
 
     async def _run_escalation_inner(self, task_id: str, finding_id: str, orig_severity: str) -> None:
         from app.agents.escalate import EscalateHunter
@@ -3063,8 +3203,32 @@ class TaskRunner:
         )
         cancel_event = threading.Event()
         self._escalation_cancel_events[finding_id] = cancel_event
+        self._live_escalations[finding_id] = {
+            "finding_id": finding_id,
+            "target_id": target_id,
+            "title": finding_dict.get("title") or "",
+            "severity": orig_severity,
+            "action": "扩大危害启动中…",
+            "started_at": _now_iso(),
+        }
 
         def emit(kind: str, data: dict):
+            st = self._live_escalations.get(finding_id)
+            if st is not None:
+                if kind == "escalate_http":
+                    st["action"] = f"HTTP {data.get('url', '')}"[:160]
+                elif kind == "escalate_shell":
+                    st["action"] = f"$ {data.get('command', '')}"[:160]
+                elif kind == "escalate_session":
+                    st["action"] = "会话态更新"
+                elif kind == "escalate_done":
+                    st["action"] = f"升级完成: {data.get('severity', '')}"
+                elif kind == "escalate_abandon":
+                    st["action"] = f"放弃: {(data.get('reason') or '')[:100]}"
+                elif kind == "escalate_error":
+                    st["action"] = f"异常: {(data.get('error') or '')[:100]}"
+                elif kind == "escalate_start":
+                    st["action"] = "扩大危害进行中…"
             asyncio.run_coroutine_threadsafe(
                 bus.publish(task_id, {"agent": "escalation", "kind": kind, "finding_id": finding_id, **data}),
                 loop,
@@ -3226,6 +3390,19 @@ class OrchestratorManager:
             tgt.last_error = ""
             await session.commit()
         return {"ok": True, "target_id": target_id, "host": host}
+
+    def inject_directive(self, task_id: str, target_id: str, directive: str) -> dict:
+        runner = self.get_runner(task_id)
+        if runner is None:
+            return {"ok": False, "error": "任务未在运行"}
+        return runner.inject_directive(target_id, directive)
+
+    def cancel_escalation(self, task_id: str, finding_id: str,
+                          reason: str = "用户取消扩大危害") -> dict:
+        runner = self.get_runner(task_id)
+        if runner is None:
+            return {"ok": False, "error": "任务未在运行"}
+        return runner.cancel_escalation(finding_id, reason)
 
     def diagnostic_snapshot(self) -> dict:
         return {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -216,7 +216,7 @@ export const api = {
   updateTask: (id, data) => req("PATCH", `/api/tasks/${id}`, data),
   // 删除任务：必须带 full 令牌（作为二次身份校验，独立于当前登录令牌）。
   deleteTask: (id, token) => req("DELETE", `/api/tasks/${id}`, undefined, false, sanitizeToken(token)),
-  board: (id) => req("GET", `/api/tasks/${id}/board`),
+  board: (id, opts = {}) => req("GET", `/api/tasks/${id}/board${qs(opts)}`),
   hardTargets: (status, q, opts = {}) => req("GET", `/api/tasks/hard-targets${qs({ status, q, ...opts })}`),
   start: (id) => req("POST", `/api/tasks/${id}/start`),
   pause: (id) => req("POST", `/api/tasks/${id}/pause`),
@@ -228,6 +228,12 @@ export const api = {
   archivedList: (id, q, opts = {}) => req("GET", `/api/tasks/${id}/archived${qs({ q, ...opts })}`),
   restoreArchived: (id) => req("POST", `/api/results/${id}/restore`),
   skipTarget: (taskId, targetId) => req("POST", `/api/tasks/${taskId}/targets/${targetId}/skip`),
+  targetTrace: (taskId, targetId, limit = 200) =>
+    req("GET", `/api/tasks/${taskId}/targets/${targetId}/trace${qs({ limit })}`),
+  injectDirective: (taskId, targetId, directive) =>
+    req("POST", `/api/tasks/${taskId}/targets/${targetId}/directive`, { directive }),
+  cancelEscalation: (taskId, findingId) =>
+    req("POST", `/api/tasks/${taskId}/escalations/${findingId}/cancel`),
   killsweeps: (id, q) => req("GET", `/api/tasks/${id}/killsweeps${qs({ q })}`),
   invalidateKillsweep: (taskId, killsweepId, reason) =>
     req("POST", `/api/tasks/${taskId}/killsweeps/${killsweepId}/invalidate`, { reason }),

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1803,6 +1803,8 @@ main {
   transition: border-color .15s ease, transform .15s ease, background-color .15s ease;
 }
 .worker-card:hover { transform: translateY(-1px); border-color: var(--border); background: var(--surface); }
+.worker-card.clickable { cursor: pointer; }
+.worker-card.clickable:hover { border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
 .wc-top { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
 .wc-host {
   font-weight: 600; font-size: 13.5px; color: var(--ink);
@@ -1891,6 +1893,103 @@ main {
 .ag-worker { color: var(--warn); }
 .ag-reviewer { color: var(--ok); }
 .ag-killsweep { color: var(--accent-ink); }
+.ag-escalation { color: #b45309; }
+
+.ev.expandable { cursor: pointer; }
+.ev.expandable:hover { background: var(--surface); border-color: var(--border-soft); }
+.ev.expandable.open { background: var(--surface); border-color: var(--border); }
+.ev-toggle {
+  width: 12px; flex: none; font-size: 9px; color: var(--faint);
+  text-align: center; line-height: 1;
+}
+.ev-toggle.spacer { visibility: hidden; }
+.ev-details {
+  margin: 0 0 6px 22px;
+  padding: 6px 8px 8px;
+  border-left: 2px solid var(--border);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.ev-detail-row {
+  display: grid;
+  grid-template-columns: 36px 92px 1fr auto;
+  gap: 8px; align-items: baseline;
+  padding: 3px 4px;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 11px; color: var(--ink-2);
+}
+.ev-detail-row.muted { color: var(--faint); grid-template-columns: 1fr; }
+.ev-detail-round { color: var(--accent-ink); font-weight: 700; }
+.ev-detail-kind { color: var(--faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ev-detail-msg { min-width: 0; word-break: break-word; }
+.ev-detail-time { color: var(--faint); white-space: nowrap; font-size: 10.5px; }
+@media (max-width: 640px) {
+  .ev-detail-row { grid-template-columns: 32px 1fr auto; }
+  .ev-detail-kind { display: none; }
+}
+
+.col-head.sub { margin-top: 16px; margin-bottom: 8px; }
+.escalate-block { margin-top: 4px; }
+.escalate-card .wc-host::before { background: #b45309; }
+
+/* Worker 轨迹抽屉 */
+.worker-trace-drawer {
+  width: min(560px, 96vw);
+}
+.worker-trace-drawer .drawer-content { padding: 0; }
+.trace-head {
+  display: flex; justify-content: space-between; gap: 12px; align-items: flex-start;
+  padding: 18px 20px 14px; border-bottom: 1px solid var(--border-soft);
+}
+.trace-head h3 {
+  margin: 4px 0 6px; font-size: 17px; line-height: 1.3;
+  word-break: break-all;
+}
+.trace-head .eyebrow {
+  font-size: 11px; letter-spacing: .08em; color: var(--faint);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+.trace-close {
+  flex: none; border: 1px solid var(--border); background: var(--surface);
+  border-radius: 8px; padding: 8px 12px; cursor: pointer; color: var(--ink-2);
+}
+.trace-directive {
+  padding: 14px 20px; border-bottom: 1px solid var(--border-soft);
+  display: flex; flex-direction: column; gap: 8px;
+  background: var(--surface);
+}
+.trace-directive label { font-size: 12px; font-weight: 600; color: var(--ink-2); }
+.trace-directive textarea {
+  width: 100%; resize: vertical; min-height: 72px;
+  border: 1px solid var(--border); border-radius: 10px;
+  background: var(--bg); color: var(--ink); padding: 10px 12px;
+  font: inherit; line-height: 1.45;
+}
+.trace-directive button.primary {
+  align-self: flex-end; background: var(--accent); color: #fff;
+  border: none; border-radius: 8px; padding: 9px 14px; cursor: pointer; font-weight: 600;
+}
+.trace-directive button.primary:disabled { opacity: .5; cursor: not-allowed; }
+.trace-list {
+  flex: 1; overflow-y: auto; padding: 10px 12px 24px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.trace-row {
+  display: grid;
+  grid-template-columns: 42px 110px 1fr auto;
+  gap: 8px; align-items: baseline;
+  padding: 7px 8px; border-radius: 8px;
+  font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: 11.5px;
+  border: 1px solid transparent;
+}
+.trace-row:hover { background: var(--surface); border-color: var(--border-soft); }
+.trace-round { color: var(--accent-ink); font-weight: 700; }
+.trace-kind { color: var(--faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.trace-msg { color: var(--ink-2); word-break: break-word; min-width: 0; }
+.trace-time { color: var(--faint); font-size: 11px; white-space: nowrap; }
+@media (max-width: 640px) {
+  .trace-row { grid-template-columns: 36px 1fr auto; }
+  .trace-kind { display: none; }
+}
 
 /* ---------- 结果行 ---------- */
 .result-row {

--- a/frontend/src/views/BoardView.vue
+++ b/frontend/src/views/BoardView.vue
@@ -13,6 +13,7 @@ const tab = ref("board");          // board | review | submit | killsweep | reje
 const boardPanel = ref("workers"); // workers | stream（手机端看板切换）
 const events = ref([]);
 const liveWorkers = ref([]);       // 在跑 worker 活态
+const liveEscalations = ref([]);   // 扩大危害活态
 const siteCollab = ref(null);      // 单站协作态势（三阶段路线流水线，仅 site 任务）
 const queue = ref([]);             // 复审队列
 const submitItems = ref([]);       // 待提交
@@ -28,6 +29,15 @@ const drawerMode = ref("view");
 const toastMsg = ref("");
 const editOpen = ref(false);
 const invalidatingKillsweepId = ref(null);
+const traceOpen = ref(false);
+const traceWorker = ref(null);
+const traceEvents = ref([]);
+const traceLoading = ref(false);
+const directiveText = ref("");
+const directiveSending = ref(false);
+const cancellingEscalateId = ref(null);
+const expandedEventKeys = ref(new Set());
+const streamDetailLoading = ref({});
 const readonly = computed(() => authRoleRef.value !== "full");
 const initialLoading = ref(false);
 const refreshing = ref(false);
@@ -40,12 +50,15 @@ const ARCHIVED_PAGE_SIZE = 50;
 const bulkWorking = ref(false);
 const SUBMIT_PAGE_SIZE = 120;
 const EXPORT_PAGE_SIZE = 80;
+const STREAM_DETAIL_CAP = 40;
 let ws = null, poll = null, boardPoll = null, searchTimer = null;
 let wsReconnectTimer = null, wsReconnectAttempt = 0, wsIntentionalClose = false;
 let eventRefreshTimer = null, eventRefreshPending = null;
 const LIST_TABS = new Set(["review", "submit", "killsweep", "rejected", "archived"]);
 // 记录哪些列表 tab 已经加载过数据：首屏只拉看板，列表按需加载；后台只刷新看过的列表。
 const loadedTabs = ref(new Set());
+// 内存中按 target 聚合的实时轨迹（WS 推送），配合落库 trace API 做回放。
+const liveTraceByTarget = ref({});
 
 function toast(m) { toastMsg.value = m; setTimeout(() => (toastMsg.value = ""), 2200); }
 
@@ -219,9 +232,17 @@ function resetTaskState(full = true) {
   }
   events.value = [];
   liveWorkers.value = [];
+  liveEscalations.value = [];
+  liveTraceByTarget.value = {};
+  expandedEventKeys.value = new Set();
+  streamDetailLoading.value = {};
   siteCollab.value = null;
   drawerId.value = null;
   editOpen.value = false;
+  traceOpen.value = false;
+  traceWorker.value = null;
+  traceEvents.value = [];
+  directiveText.value = "";
 }
 
 async function bootstrapTask() {
@@ -245,7 +266,7 @@ async function bootstrapTask() {
   }
 }
 
-// 实时事件：只展示稍重要的事件，过滤 HTTP/Shell/思考等高频低价值噪音。
+// 实时事件：活动流只展示里程碑；tool/thought 等细节静默缓冲，点击行再展开。
 const IMPORTANT_KINDS = new Set([
   "collector_phase",
   "finding_submitted", "finding_duplicate", "finding_invalid",
@@ -258,6 +279,8 @@ const IMPORTANT_KINDS = new Set([
   "llm_error", "llm_soft_retry", "llm_interrupt", "worker_resume", "llm_provider_failed", "quota_stop", "reclaim", "recover", "workers_cancelled",
   "tool_exception",
   "auth_status",
+  "escalate_start", "escalate_done", "escalate_skip", "escalate_cancelled", "escalate_error", "escalate_abandon",
+  "worker_directive", "worker_directive_queued",
 ]);
 const NOISE_KINDS = new Set([
   "ping",
@@ -265,6 +288,8 @@ const NOISE_KINDS = new Set([
   "tool_js_analyze", "tool_decode", "tool_waf_advice", "tool_fofa_lookup", "tool_session_set",
   "worker_thought", "intel_reported", "js_analyzer_enabled",
   "killsweep_fofa", "killsweep_http", "killsweep_shell",
+  "escalate_http", "escalate_shell", "escalate_session",
+  "llm_round_start",
   "refill", "cluster_cooldown_skip", "skip",
 ]);
 const LOG_INFO_IMPORTANT = new Set([
@@ -272,6 +297,21 @@ const LOG_INFO_IMPORTANT = new Set([
   "review_done", "review_deferred", "review_cancelled",
   "reclaim", "recover", "workers_cancelled", "quota_stop",
   "killsweep_done", "killsweep_dedup", "killsweep_error", "killsweep_cancelled",
+  "escalate_done", "escalate_skip", "escalate_cancelled",
+]);
+const TRACE_KINDS = new Set([
+  ...NOISE_KINDS,
+  "worker_start", "worker_finish", "worker_cancelled", "worker_auto_finish",
+  "worker_thought", "worker_directive", "worker_resume",
+  "llm_round_start", "llm_error", "llm_soft_retry", "llm_interrupt",
+  "finding_submitted", "finding_duplicate", "finding_invalid",
+  "tool_exception", "auth_status", "finish_blocked",
+]);
+const DETAIL_KINDS = new Set([
+  "tool_http", "tool_shell", "tool_shell_blocked", "tool_arg_error",
+  "tool_js_analyze", "tool_decode", "tool_waf_advice", "tool_fofa_lookup", "tool_session_set",
+  "worker_thought", "worker_directive", "llm_round_start", "llm_error", "llm_soft_retry",
+  "tool_exception", "finish_blocked", "auth_status",
 ]);
 
 function isImportantEvent(ev) {
@@ -284,6 +324,80 @@ function isImportantEvent(ev) {
   if (ev.message && LOG_INFO_IMPORTANT.has(kind)) return true;
   if (ev.message && kind === "error") return true;
   return false;
+}
+
+function pushLiveTrace(ev) {
+  const tid = ev.target_id;
+  if (!tid || !TRACE_KINDS.has(ev.kind || "")) return;
+  const map = { ...liveTraceByTarget.value };
+  const list = [...(map[tid] || [])];
+  list.push({ ...ev, _text: fmtEvent(ev) || ev.kind });
+  if (list.length > 300) list.splice(0, list.length - 300);
+  map[tid] = list;
+  liveTraceByTarget.value = map;
+  if (traceOpen.value && traceWorker.value?.target_id === tid) {
+    traceEvents.value = [...list].reverse();
+  }
+}
+
+function eventExpandKey(ev, i) {
+  return `${ev.target_id || ""}|${ev.ts || ""}|${ev.kind || ""}|${i}`;
+}
+
+function canExpandEvent(ev) {
+  return !!(ev?.target_id);
+}
+
+function isEventExpanded(key) {
+  return expandedEventKeys.value.has(key);
+}
+
+function detailsForTarget(targetId) {
+  const list = liveTraceByTarget.value[targetId] || [];
+  const details = list.filter((e) => DETAIL_KINDS.has(e.kind || ""));
+  // 最新在前，截断
+  const ordered = [...details].reverse();
+  return ordered.slice(0, STREAM_DETAIL_CAP);
+}
+
+async function toggleEventExpand(ev, i) {
+  if (!canExpandEvent(ev)) return;
+  const key = eventExpandKey(ev, i);
+  const next = new Set(expandedEventKeys.value);
+  if (next.has(key)) {
+    next.delete(key);
+    expandedEventKeys.value = next;
+    return;
+  }
+  next.add(key);
+  expandedEventKeys.value = next;
+  const tid = ev.target_id;
+  if ((liveTraceByTarget.value[tid] || []).some((e) => DETAIL_KINDS.has(e.kind || ""))) return;
+  if (streamDetailLoading.value[tid]) return;
+  streamDetailLoading.value = { ...streamDetailLoading.value, [tid]: true };
+  try {
+    const res = await api.targetTrace(props.id, tid, 120);
+    const rows = (res.events || []).map((e) => ({
+      ...e,
+      _text: fmtEvent(e) || e.message || e.kind,
+    }));
+    const seen = new Set();
+    const merged = [];
+    for (const e of [...(liveTraceByTarget.value[tid] || []), ...rows]) {
+      const k = `${e.ts || ""}|${e.kind}|${e.message || e._text || ""}|${e.round || ""}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      merged.push(e);
+    }
+    merged.sort((a, b) => String(a.ts || "").localeCompare(String(b.ts || "")));
+    liveTraceByTarget.value = { ...liveTraceByTarget.value, [tid]: merged };
+  } catch {
+    /* 展开区显示空态即可 */
+  } finally {
+    const loading = { ...streamDetailLoading.value };
+    delete loading[tid];
+    streamDetailLoading.value = loading;
+  }
 }
 
 // 把任意事件格式化为一句人话（worker 动作事件本身没有 message）
@@ -318,6 +432,27 @@ function fmtEvent(ev) {
     case "worker_resume": return `断点续挖：恢复笔记 ${d.notes_len || 0} 字 / cookie ${(d.cookies || []).length} / 头 ${(d.headers || []).length}`;
     case "llm_provider_failed": return `LLM 端点失败: ${d.model || ""} @ ${d.base_url || ""} (${d.error_kind || "failed"})`;
     case "tool_exception": return `工具异常: ${d.tool || ""} ${(d.error || "").slice(0, 80)}`;
+    case "tool_http": return `HTTP ${d.method || "GET"} ${d.url || ""}`;
+    case "tool_shell": return `$ ${(d.command || "").slice(0, 160)}`;
+    case "tool_shell_blocked": return `拦截命令: ${(d.reason || d.command || "").slice(0, 120)}`;
+    case "tool_arg_error": return `工具参数错误: ${d.tool || ""} ${(d.error || "").slice(0, 80)}`;
+    case "tool_js_analyze": return `JS 分析: ${(d.url || "").slice(0, 120)}`;
+    case "tool_decode": return `解码: ${d.mode || "auto"}`;
+    case "tool_waf_advice": return `WAF 建议: ${d.context || "generic"}`;
+    case "tool_fofa_lookup": return `FOFA: ${(d.query || "").slice(0, 100)}`;
+    case "tool_session_set": return `会话态更新`;
+    case "worker_thought": return `💭 ${(d.text || "").slice(0, 200)}`;
+    case "worker_directive": return `🎛 执行人工指令: ${(d.text || "").slice(0, 160)}`;
+    case "worker_directive_queued": return d.message || `已排队人工指令: ${(d.text || "").slice(0, 120)}`;
+    case "llm_round_start": return `第 ${d.round || "?"} 轮 LLM`;
+    case "escalate_start": return `扩大危害启动: ${d.title || ""}`;
+    case "escalate_done": return `扩大危害完成: ${d.title || ""} · ${d.severity || ""}`;
+    case "escalate_skip": return d.message || `扩大危害未显著，已放弃`;
+    case "escalate_cancelled": return d.message || `扩大危害已取消`;
+    case "escalate_error": return `扩大危害异常: ${(d.error || "").slice(0, 120)}`;
+    case "escalate_abandon": return `扩大危害放弃: ${(d.reason || "").slice(0, 120)}`;
+    case "escalate_http": return `扩大危害 HTTP ${(d.url || "").slice(0, 120)}`;
+    case "escalate_shell": return `扩大危害 $ ${(d.command || "").slice(0, 120)}`;
     case "auth_status": {
       const kinds = (d.kinds || []).join(",") || "-";
       const st = d.status || "?";
@@ -357,6 +492,7 @@ async function loadBoard() {
   const b = await api.board(id);
   if (id !== props.id) return;
   liveWorkers.value = b.live_workers || [];
+  liveEscalations.value = b.live_escalations || [];
   siteCollab.value = b.site_collab || null;
   if (task.value) {
     if (b.task_status) task.value.status = b.task_status;
@@ -389,15 +525,17 @@ function connectWs() {
     let ev;
     try { ev = JSON.parse(e.data); } catch { return; }   // 畸形帧不炸整个处理器
     if (ev.kind === "ping") return;
+    pushLiveTrace(ev);
     if (!isImportantEvent(ev)) return;
     if (ev.kind === "collector_phase") updateCollectorStatus(ev);
     const text = fmtEvent(ev);
     if (!text) return;
     events.value.unshift({ ...ev, _text: text });
-    if (events.value.length > 200) events.value.pop();
+    if (events.value.length > 200) events.value.length = 200;
     const k = ev.kind || "";
     if (k.includes("finding") || k.includes("review") || k.includes("target_done")
-        || k.includes("submit") || k.includes("killsweep") || k.includes("worker")) {
+        || k.includes("submit") || k.includes("killsweep") || k.includes("worker")
+        || k.includes("escalate")) {
       scheduleEventRefresh(ev);
     }
   };
@@ -530,6 +668,81 @@ async function skipTarget(w) {
     toast(`已删除目标 ${host}，将跳过`);
   } catch (e) {
     toast(`删除失败：${e?.message || e}`);
+  }
+}
+
+async function openWorkerTrace(w) {
+  if (!w?.target_id) return;
+  traceWorker.value = w;
+  traceOpen.value = true;
+  directiveText.value = "";
+  const live = liveTraceByTarget.value[w.target_id] || [];
+  if (live.length) {
+    traceEvents.value = [...live].reverse();
+  } else {
+    traceEvents.value = [];
+  }
+  traceLoading.value = true;
+  try {
+    const res = await api.targetTrace(props.id, w.target_id, 200);
+    const rows = (res.events || []).map((e) => ({ ...e, _text: fmtEvent(e) || e.message || e.kind }));
+    // 落库轨迹 + 内存实时轨迹合并去重（按 ts+kind+message）
+    const seen = new Set();
+    const merged = [];
+    for (const e of [...rows, ...(liveTraceByTarget.value[w.target_id] || [])]) {
+      const key = `${e.ts || ""}|${e.kind}|${e.message || e._text || ""}|${e.round || ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push({ ...e, _text: e._text || fmtEvent(e) || e.message || e.kind });
+    }
+    merged.sort((a, b) => String(a.ts || "").localeCompare(String(b.ts || "")));
+    traceEvents.value = merged.reverse();
+    liveTraceByTarget.value = {
+      ...liveTraceByTarget.value,
+      [w.target_id]: [...merged],
+    };
+  } catch (e) {
+    if (!traceEvents.value.length) toast(`加载轨迹失败：${e?.message || e}`);
+  } finally {
+    traceLoading.value = false;
+  }
+}
+
+function closeWorkerTrace() {
+  traceOpen.value = false;
+  traceWorker.value = null;
+  directiveText.value = "";
+}
+
+async function sendDirective() {
+  if (readonly.value || !traceWorker.value || directiveSending.value) return;
+  const text = directiveText.value.trim();
+  if (!text) return;
+  directiveSending.value = true;
+  try {
+    await api.injectDirective(props.id, traceWorker.value.target_id, text);
+    toast("指令已排队，下一轮 LLM 前生效");
+    directiveText.value = "";
+  } catch (e) {
+    toast(`注入失败：${e?.message || e}`);
+  } finally {
+    directiveSending.value = false;
+  }
+}
+
+async function cancelEscalation(e) {
+  if (readonly.value || cancellingEscalateId.value) return;
+  const title = shortText(e.title || e.finding_id || "扩大危害");
+  if (!window.confirm(`确认取消「${title}」的扩大危害？`)) return;
+  cancellingEscalateId.value = e.finding_id;
+  try {
+    await api.cancelEscalation(props.id, e.finding_id);
+    liveEscalations.value = liveEscalations.value.filter((x) => x.finding_id !== e.finding_id);
+    toast("已取消扩大危害");
+  } catch (err) {
+    toast(`取消失败：${err?.message || err}`);
+  } finally {
+    cancellingEscalateId.value = null;
   }
 }
 
@@ -701,8 +914,8 @@ async function exportEdusrcAll() {
   }
 }
 
-const AGENT_ICON = { orchestrator: "◆", collector: "🛰", worker: "⚔", reviewer: "⚖", killsweep: "◇" };
-const AGENT_LABEL = { orchestrator: "主控", collector: "搜集", worker: "挖掘", reviewer: "审核", killsweep: "通杀" };
+const AGENT_ICON = { orchestrator: "◆", collector: "🛰", worker: "⚔", reviewer: "⚖", killsweep: "◇", escalation: "⬆" };
+const AGENT_LABEL = { orchestrator: "主控", collector: "搜集", worker: "挖掘", reviewer: "审核", killsweep: "通杀", escalation: "扩大危害" };
 
 const stats = computed(() => task.value?.stats || {});
 // Tab 徽标/指标卡计数：统一以 stats 为权威来源（stats 随 loadTask 在挂载时与每次实时事件刷新），
@@ -1123,9 +1336,14 @@ function parseEventTs(ts) {
       </div>
       <!-- Worker 矩阵 -->
       <div class="board-col board-panel" :class="{ 'board-panel-hidden': boardPanel !== 'workers' }">
-        <div class="col-head"><span>Worker Matrix</span><small>挖掘中</small><i class="cnt">{{ liveWorkers.length }}</i></div>
+        <div class="col-head">
+          <span>Worker Matrix</span>
+          <small>点击卡片查看轨迹</small>
+          <i class="cnt">{{ liveWorkers.length }}</i>
+        </div>
         <div v-if="!liveWorkers.length" class="empty sm">暂无运行中的 worker</div>
-        <div v-for="w in liveWorkers" :key="w.target_id" class="worker-card">
+        <div v-for="w in liveWorkers" :key="w.target_id" class="worker-card clickable"
+          @click="openWorkerTrace(w)" title="查看执行轨迹 / 注入指令">
           <div class="wc-top">
             <span class="wc-host">{{ w.host }}</span>
             <span class="wc-meta">
@@ -1133,7 +1351,7 @@ function parseEventTs(ts) {
               <span v-if="w.score > 0" class="wc-score" :title="w.score_reason">★{{ w.score }}</span>
               第 {{ w.round }} 轮 · {{ elapsed(w.started_at) }}
               <button v-if="!readonly" type="button" class="wc-del"
-                title="删除该目标（跳过本次任务的这个目标）" @click="skipTarget(w)">✕</button>
+                title="删除该目标（跳过本次任务的这个目标）" @click.stop="skipTarget(w)">✕</button>
             </span>
           </div>
           <div class="wc-action">{{ w.action }}</div>
@@ -1149,19 +1367,69 @@ function parseEventTs(ts) {
             <span class="wc-bar"><i :style="{ transform: `scaleX(${Math.min(1, w.round / 60)})` }"></i></span>
           </div>
         </div>
+
+        <!-- 扩大危害活态 -->
+        <div v-if="liveEscalations.length" class="escalate-block">
+          <div class="col-head sub"><span>扩大危害</span><small>进行中</small><i class="cnt">{{ liveEscalations.length }}</i></div>
+          <div v-for="e in liveEscalations" :key="e.finding_id" class="worker-card escalate-card">
+            <div class="wc-top">
+              <span class="wc-host">{{ e.title || e.finding_id }}</span>
+              <span class="wc-meta">
+                <span v-if="e.severity" class="wc-score">{{ e.severity }}</span>
+                {{ elapsed(e.started_at) }}
+                <button v-if="!readonly" type="button" class="wc-del"
+                  title="取消扩大危害"
+                  :disabled="cancellingEscalateId === e.finding_id"
+                  @click.stop="cancelEscalation(e)">✕</button>
+              </span>
+            </div>
+            <div class="wc-action">{{ e.action || "扩大危害进行中…" }}</div>
+          </div>
+        </div>
       </div>
 
       <!-- 活动流 -->
       <div class="board-col board-panel" :class="{ 'board-panel-hidden': boardPanel !== 'stream' }">
-        <div class="col-head"><span>Activity Stream</span><small>重要事件</small></div>
+        <div class="col-head">
+          <span>Activity Stream</span>
+          <small>点击带目标的行展开细节</small>
+        </div>
         <div class="event-log">
           <div v-if="!events.length" class="empty sm">等待事件…</div>
-          <div v-for="(ev, i) in events" :key="i" :class="evClass(ev)">
-            <span class="ev-icon" :class="`ag-${ev.agent}`">{{ AGENT_ICON[ev.agent] || "•" }}</span>
-            <span class="ev-agent" :class="`ag-${ev.agent}`">{{ AGENT_LABEL[ev.agent] || ev.agent }}</span>
-            <span class="ev-msg">{{ ev._text }}</span>
-            <span class="ev-time">{{ evTime(ev) }}</span>
-          </div>
+          <template v-for="(ev, i) in events" :key="eventExpandKey(ev, i)">
+            <div
+              :class="[evClass(ev), { expandable: canExpandEvent(ev), open: isEventExpanded(eventExpandKey(ev, i)) }]"
+              @click="toggleEventExpand(ev, i)"
+            >
+              <span v-if="canExpandEvent(ev)" class="ev-toggle" aria-hidden="true">
+                {{ isEventExpanded(eventExpandKey(ev, i)) ? "▼" : "▶" }}
+              </span>
+              <span v-else class="ev-toggle spacer" aria-hidden="true"></span>
+              <span class="ev-icon" :class="`ag-${ev.agent}`">{{ AGENT_ICON[ev.agent] || "•" }}</span>
+              <span class="ev-agent" :class="`ag-${ev.agent}`">{{ AGENT_LABEL[ev.agent] || ev.agent }}</span>
+              <span class="ev-msg">{{ ev._text }}</span>
+              <span class="ev-time">{{ evTime(ev) }}</span>
+            </div>
+            <div
+              v-if="canExpandEvent(ev) && isEventExpanded(eventExpandKey(ev, i))"
+              class="ev-details"
+            >
+              <div v-if="streamDetailLoading[ev.target_id]" class="ev-detail-row muted">加载细节…</div>
+              <div v-else-if="!detailsForTarget(ev.target_id).length" class="ev-detail-row muted">
+                暂无工具/思考细节（等待 worker 产出或稍后重试）
+              </div>
+              <div
+                v-for="(d, di) in detailsForTarget(ev.target_id)"
+                :key="di"
+                class="ev-detail-row"
+              >
+                <span class="ev-detail-round" v-if="d.round">R{{ d.round }}</span>
+                <span class="ev-detail-kind">{{ d.kind }}</span>
+                <span class="ev-detail-msg">{{ d._text || d.message || d.kind }}</span>
+                <span class="ev-detail-time">{{ evTime(d) }}</span>
+              </div>
+            </div>
+          </template>
         </div>
       </div>
     </div>
@@ -1339,6 +1607,47 @@ function parseEventTs(ts) {
 
     <ReportDrawer :finding-id="drawerId" :mode="drawerMode" :src-type="task.src_type"
       @close="drawerId = null" @updated="onDrawerUpdated" @toast="toast" />
+
+    <!-- Worker 执行轨迹抽屉 -->
+    <div v-if="traceOpen" class="drawer-mask" @click.self="closeWorkerTrace">
+      <aside class="drawer open worker-trace-drawer" role="dialog" aria-modal="true">
+        <div class="drawer-content">
+          <header class="trace-head">
+            <div>
+              <div class="eyebrow">WORKER TRACE</div>
+              <h3>{{ traceWorker?.host || "执行轨迹" }}</h3>
+              <p class="meta">
+                第 {{ traceWorker?.round || 0 }} 轮 · {{ elapsed(traceWorker?.started_at) }}
+                <template v-if="traceWorker?.action"> · {{ traceWorker.action }}</template>
+              </p>
+            </div>
+            <button type="button" class="trace-close" @click="closeWorkerTrace">关闭</button>
+          </header>
+
+          <div v-if="!readonly" class="trace-directive">
+            <label>人工实时指令（下一轮 LLM 前注入）</label>
+            <textarea v-model="directiveText" rows="3"
+              placeholder="例如：优先验证 /api/user/list 的越权；不要再扫目录，直接打 IDOR"></textarea>
+            <button type="button" class="primary" :disabled="directiveSending || !directiveText.trim()"
+              @click="sendDirective">
+              {{ directiveSending ? "发送中…" : "注入指令" }}
+            </button>
+          </div>
+
+          <div class="trace-list">
+            <div v-if="traceLoading && !traceEvents.length" class="empty sm">加载轨迹…</div>
+            <div v-else-if="!traceEvents.length" class="empty sm">暂无轨迹（等 worker 产生工具调用后刷新）</div>
+            <div v-for="(ev, i) in traceEvents" :key="i" class="trace-row" :class="ev.kind">
+              <span class="trace-round" v-if="ev.round">R{{ ev.round }}</span>
+              <span class="trace-kind">{{ ev.kind }}</span>
+              <span class="trace-msg">{{ ev._text || ev.message || ev.kind }}</span>
+              <span class="trace-time">{{ evTime(ev) }}</span>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+
     <div v-if="toastMsg" class="toast">{{ toastMsg }}</div>
     </template>
   </section>

--- a/frontend/src/views/TasksView.vue
+++ b/frontend/src/views/TasksView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed, watch } from "vue";
+import { ref, onMounted, onUnmounted, computed, watch } from "vue";
 import { useRouter } from "vue-router";
 import { api, authReadyRef, authRequiredRef, authRoleRef, loadAuthRole, verifyToken } from "../api.js";
 import TaskEditModal from "../components/TaskEditModal.vue";
@@ -11,6 +11,7 @@ const editOpen = ref(false);
 const editingTask = ref(null);
 const writable = computed(() => authRoleRef.value === "full");
 const router = useRouter();
+let pollTimer = null;
 
 const STATUS_LABEL = {
   running: "运行中",
@@ -37,13 +38,25 @@ function taskScopeText(t) {
   return t?.fofa_query || "手动清单";
 }
 
-async function load() {
+const hasRunning = computed(() => tasks.value.some((t) => t.status === "running"));
+
+function syncPoller() {
+  clearInterval(pollTimer);
+  pollTimer = null;
+  // 有运行中任务时加快刷新；否则慢轮询，仍能感知远端状态变化。
+  const ms = hasRunning.value ? 5000 : 15000;
+  pollTimer = setInterval(() => load({ background: true }), ms);
+}
+
+async function load(opts = {}) {
+  const background = !!opts.background;
   if (!tasks.value.length) initialLoading.value = true;
-  else refreshing.value = true;
+  else if (!background) refreshing.value = true;
   try { tasks.value = await api.listTasks(); }
   finally {
     initialLoading.value = false;
     refreshing.value = false;
+    syncPoller();
   }
 }
 async function openEdit(task) {
@@ -115,9 +128,14 @@ onMounted(async () => {
   if (!authReadyRef.value) await loadAuthRole();
   await load();
 });
+onUnmounted(() => {
+  clearInterval(pollTimer);
+  pollTimer = null;
+});
 watch(authReadyRef, (ready) => {
   if (ready) load();
 });
+watch(hasRunning, () => syncPoller());
 </script>
 
 <template>

--- a/tests/test_agent_visibility.py
+++ b/tests/test_agent_visibility.py
@@ -1,0 +1,275 @@
+"""Agent 可见性 / 可控性：API 过滤规则 + orchestrator 指令/扩大危害 + worker 注入。
+
+不启 Docker 浏览器、不调真实 LLM，几秒内回归。
+运行：
+  python -m unittest tests.test_agent_visibility -q
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.agents.worker import Worker  # noqa: E402
+from app.api import tasks as tasks_api  # noqa: E402
+from app.api.dto import DirectiveRequest  # noqa: E402
+from app.llm.client import LLMError  # noqa: E402
+from app.orchestrator import TaskRunner, manager  # noqa: E402
+from app.schemas import Verdict  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+
+class StreamFilterTests(unittest.TestCase):
+    def test_noise_always_hidden(self):
+        self.assertFalse(tasks_api._stream_event_visible("ping", "info"))
+        self.assertFalse(tasks_api._stream_event_visible("refill", "info", verbose=True))
+
+    def test_important_always_visible(self):
+        self.assertTrue(tasks_api._stream_event_visible("target_done", "info"))
+        self.assertTrue(tasks_api._stream_event_visible("escalate_done", "info"))
+        self.assertTrue(tasks_api._stream_event_visible("worker_directive_queued", "info"))
+
+    def test_trace_kinds_only_in_verbose(self):
+        self.assertFalse(tasks_api._stream_event_visible("tool_http", "info"))
+        self.assertFalse(tasks_api._stream_event_visible("worker_thought", "info"))
+        self.assertTrue(tasks_api._stream_event_visible("tool_http", "info", verbose=True))
+        self.assertTrue(tasks_api._stream_event_visible("worker_thought", "info", verbose=True))
+        self.assertTrue(tasks_api._stream_event_visible("escalate_http", "info", verbose=True))
+
+    def test_warn_error_always_visible(self):
+        self.assertTrue(tasks_api._stream_event_visible("whatever", "warn"))
+        self.assertTrue(tasks_api._stream_event_visible("tool_http", "error"))
+
+
+class DirectiveRequestTests(unittest.TestCase):
+    def test_accepts_nonempty(self):
+        body = DirectiveRequest(directive="  优先打 IDOR  ")
+        self.assertEqual(body.directive, "  优先打 IDOR  ")
+
+    def test_rejects_empty(self):
+        with self.assertRaises(ValidationError):
+            DirectiveRequest(directive="")
+
+
+class TaskRunnerDirectiveTests(unittest.TestCase):
+    def test_inject_requires_active_worker(self):
+        runner = TaskRunner("task-vis")
+        res = runner.inject_directive("t1", " dig deeper ")
+        self.assertFalse(res["ok"])
+        self.assertIn("没有运行中", res["error"])
+
+    def test_inject_rejects_blank(self):
+        runner = TaskRunner("task-vis")
+        runner._active_workers["t1"] = object()  # type: ignore[assignment]
+        res = runner.inject_directive("t1", "   ")
+        self.assertFalse(res["ok"])
+        self.assertIn("不能为空", res["error"])
+
+    def test_inject_and_pop_fifo(self):
+        runner = TaskRunner("task-vis")
+        runner._active_workers["t1"] = object()  # type: ignore[assignment]
+        runner._live["t1"] = {"host": "example.edu"}
+
+        a = runner.inject_directive("t1", "先做登录")
+        b = runner.inject_directive("t1", "再打越权")
+        self.assertTrue(a["ok"] and b["ok"])
+        self.assertEqual(a["host"], "example.edu")
+        self.assertEqual(runner._pop_directive("t1"), "先做登录")
+        self.assertEqual(runner._pop_directive("t1"), "再打越权")
+        self.assertIsNone(runner._pop_directive("t1"))
+        self.assertNotIn("t1", runner._worker_directives)
+
+    def test_inject_truncates_to_2000(self):
+        runner = TaskRunner("task-vis")
+        runner._active_workers["t1"] = object()  # type: ignore[assignment]
+        long = "x" * 5000
+        res = runner.inject_directive("t1", long)
+        self.assertTrue(res["ok"])
+        self.assertEqual(len(runner._pop_directive("t1") or ""), 2000)
+
+
+class TaskRunnerEscalationTests(unittest.TestCase):
+    def test_cancel_missing(self):
+        runner = TaskRunner("task-vis")
+        res = runner.cancel_escalation("f1")
+        self.assertFalse(res["ok"])
+
+    def test_cancel_sets_event_and_clears_live(self):
+        runner = TaskRunner("task-vis")
+        ev = threading.Event()
+        runner._escalation_inflight.add("f1")
+        runner._escalation_cancel_events["f1"] = ev
+        runner._live_escalations["f1"] = {"title": "越权读订单", "finding_id": "f1"}
+
+        res = runner.cancel_escalation("f1", reason="测试取消")
+        self.assertTrue(res["ok"])
+        self.assertTrue(ev.is_set())
+        self.assertEqual(res["title"], "越权读订单")
+        self.assertNotIn("f1", runner._live_escalations)
+
+    def test_live_escalations_list(self):
+        runner = TaskRunner("task-vis")
+        runner._live_escalations["f1"] = {"finding_id": "f1", "action": "扩大危害进行中…"}
+        items = runner.live_escalations()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["finding_id"], "f1")
+
+
+class TracePayloadTests(unittest.TestCase):
+    def test_truncate_drops_finding_and_long_text(self):
+        payload = {
+            "finding": {"huge": True},
+            "text": "t" * 800,
+            "command": "c" * 600,
+            "url": "https://example.edu/" + "a" * 400,
+            "round": 3,
+            "kinds": ["cookie", "pass"],
+        }
+        out = TaskRunner._truncate_trace_payload(payload)
+        self.assertNotIn("finding", out)
+        self.assertEqual(len(out["text"]), 500)
+        self.assertEqual(len(out["command"]), 500)
+        self.assertEqual(out["round"], 3)
+        self.assertEqual(out["kinds"], ["cookie", "pass"])
+
+
+class ManagerWrapperTests(unittest.TestCase):
+    def test_inject_without_runner(self):
+        # 确保不误伤真实 runner：用一个绝不可能冲突的 id
+        tid = "__visibility_test_missing__"
+        manager._runners.pop(tid, None)
+        res = manager.inject_directive(tid, "t1", "hello")
+        self.assertFalse(res["ok"])
+        self.assertIn("未在运行", res["error"])
+
+    def test_cancel_escalation_without_runner(self):
+        tid = "__visibility_test_missing__"
+        manager._runners.pop(tid, None)
+        res = manager.cancel_escalation(tid, "f1")
+        self.assertFalse(res["ok"])
+
+
+class _SessionContext:
+    def __init__(self, session) -> None:
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class PersistTraceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_persist_skips_non_trace_kinds(self):
+        runner = TaskRunner("task-vis")
+        session = SimpleNamespace(add=Mock(), commit=AsyncMock())
+        with patch("app.orchestrator.SessionLocal", return_value=_SessionContext(session)):
+            await runner._persist_worker_trace("task-vis", "t1", "ping", {"x": 1})
+        session.add.assert_not_called()
+
+    async def test_persist_writes_task_event(self):
+        runner = TaskRunner("task-vis")
+        session = SimpleNamespace(add=Mock(), commit=AsyncMock())
+        with patch("app.orchestrator.SessionLocal", return_value=_SessionContext(session)):
+            await runner._persist_worker_trace(
+                "task-vis", "t1", "tool_http",
+                {"method": "GET", "url": "https://example.edu/api", "round": 2},
+            )
+        session.add.assert_called_once()
+        event = session.add.call_args[0][0]
+        self.assertEqual(event.agent, "worker")
+        self.assertEqual(event.kind, "tool_http")
+        self.assertEqual(event.payload.get("target_id"), "t1")
+        self.assertIn("GET", event.message)
+        session.commit.assert_awaited_once()
+
+
+class WorkerDirectiveInjectionTests(unittest.TestCase):
+    def test_directive_injected_before_llm_round(self):
+        """pop_directive 返回内容后，应 emit worker_directive，并把指令塞进 messages。"""
+        captured: list = []
+
+        class FakeLLM:
+            def chat(self, messages, tools=None, tool_choice=None):
+                captured.append(list(messages))
+                # 立刻报错结束，避免继续挖；软重试路径外的 interrupt
+                raise LLMError("fatal", "stop-after-directive")
+
+        worker = Worker.__new__(Worker)
+        worker.deepen_context = None
+        worker.target = "https://example.invalid"
+        worker.src_type = "enterprise"
+        worker.prompt_version = "test"
+        worker.cancel_event = threading.Event()
+        worker.findings = []
+        worker._finished = None
+        worker._js_tool_enabled = False
+        worker._reported_intel = []
+        worker._reported_coverage = []
+        worker._intel_block = Mock(return_value="")
+        worker._duplicate_block = Mock(return_value="")
+        worker._emit = Mock()
+        worker._route_rounds = Mock(return_value=(2, 1))
+        worker._should_soft_retry_llm = Mock(return_value=False)
+        worker._llm_interrupt_result = Mock(side_effect=lambda **kw: SimpleNamespace(
+            target=worker.target, verdict=Verdict.error, findings=[],
+            rounds=kw.get("rounds", 0), error=kw.get("error", ""),
+            deepen_lead="", failure_kind=kw.get("failure_kind", ""),
+            retry_after_seconds=0, model_dump=lambda mode="json": {},
+        ))
+        worker._cancelled_result = Mock()
+        worker.executor = SimpleNamespace(
+            session_status_block=Mock(return_value="session"),
+            kill_processes=Mock(),
+        )
+        worker.llm = FakeLLM()
+        worker.pop_directive = Mock(return_value="只测 /api/admin 越权")
+        worker.target_meta = {}
+        worker.duplicate_history = []
+
+        # run() 开头会 bootstrap auth / restore；一并短路
+        worker._bootstrap_user_auth = Mock()
+        worker._restore_interrupt_progress = Mock()
+
+        worker.run()
+
+        # 发出了指令事件
+        kinds = [c.args[0] for c in worker._emit.call_args_list]
+        self.assertIn("worker_directive", kinds)
+        # 发给 LLM 的消息里包含人工指令
+        self.assertTrue(captured, "应至少发起一轮 LLM")
+        blob = "\n".join(
+            (m.get("content") or "") if isinstance(m, dict) else ""
+            for m in captured[0]
+        )
+        self.assertIn("人工实时指令", blob)
+        self.assertIn("只测 /api/admin 越权", blob)
+
+
+class EventBusDropOldestTests(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_full_drops_oldest_keeps_newest(self):
+        from app.events import EventBus
+
+        bus = EventBus()
+        q = asyncio.Queue(maxsize=2)
+        bus._subscribers["t"] = {q}
+        await bus.publish("t", {"n": 1})
+        await bus.publish("t", {"n": 2})
+        await bus.publish("t", {"n": 3})  # 应挤掉 1
+        self.assertEqual(q.qsize(), 2)
+        a = q.get_nowait()
+        b = q.get_nowait()
+        self.assertEqual([a["n"], b["n"]], [2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 解决「不知道 agent 在干什么 / 很难控制」：活动流可折叠展开细节、Worker 轨迹抽屉、扩大危害面板，细粒度事件落库可回看
- 新增运行中干预：向 worker 注入 mid-run 指令；单独取消 escalation；任务列表后台轮询 running 状态
- 补充 `tests/test_agent_visibility.py` 契约/单元测试（过滤规则、指令队列、落库、EventBus）

## 主要改动
| 区域 | 内容 |
|------|------|
| `orchestrator.py` | 轨迹落库、directive 队列、escalation 活态/取消 |
| `worker.py` | 每轮 LLM 前注入人工指令 |
| `tasks.py` / `dto.py` | `/trace`、`/directive`、`/escalations/.../cancel`，board 返回 `live_escalations` |
| `events.py` | 队列满时丢最旧保最新 |
| `BoardView.vue` | 点击里程碑展开细节；Worker 抽屉 + Escalation UI |
| `TasksView.vue` | running 5s / 其它 15s 轮询 |

## Test plan
- [x] `python -m unittest tests.test_agent_visibility -q`（容器内或本地）通过
- [x] 启动任务后，活动流默认精简；点击带 ▶ 的行可展开 tool/thought，再点收起
- [x] 点击 Worker 卡片打开轨迹抽屉，可发送人工指令并在下一轮生效
- [x] AI accepted 触发扩大危害时，看板出现面板且可取消
- [x] 刷新页面后，已落库目标仍可通过展开/抽屉看到历史轨迹
- [x] 任务列表页不手动刷新也能感知 running 状态变化

<img width="1177" height="539" alt="image" src="https://github.com/user-attachments/assets/35ca766d-39a9-4b84-bdc6-f6bc26380ff8" />
<img width="1246" height="874" alt="image" src="https://github.com/user-attachments/assets/0fd6f9a6-93db-4a89-a0e4-7a515d966417" />

