### PR TITLE
fix: keep task edit modal open on backdrop blur

### DIFF
--- a/frontend/src/components/TaskEditModal.vue
+++ b/frontend/src/components/TaskEditModal.vue
@@ -266,7 +266,7 @@ async function save() {
 </script>
 
 <template>
-  <div v-if="open" class="task-edit-backdrop" @click.self="emit('close')">
+  <div v-if="open" class="task-edit-backdrop">
     <form class="task-edit-modal" @submit.prevent="save">
       <header>
         <div>


### PR DESCRIPTION
修复在编辑参数页面时在输入框使用鼠标时触发的失焦自动隐藏