### PR TITLE
fix: Kimi Code 端点（k3 思考模型）强制 temperature=1

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dto import SettingsUpdateRequest
 from app.config import LLMConfig
 from app.db.session import get_session
-from app.llm.client import _resolve_user_agent
+from app.llm.client import _is_kimi_coding_endpoint, _resolve_user_agent
 from app.tools.netguard import SsrfBlocked, assert_safe_outbound_url
 from app.settings_service import (
     _clean_llm_providers,
@@ -206,7 +206,8 @@ async def _probe_tool_calling(url: str, headers: dict, model: str, protocol: str
     else:
         payload = {
             "model": model,
-            "temperature": 0,
+            # Kimi Code 端点（k3 思考模型）只接受 temperature=1
+            "temperature": 1 if _is_kimi_coding_endpoint(url) else 0,
             "max_tokens": 64,
             "messages": [
                 {"role": "system", "content": "You must use the provided tool to answer."},
@@ -286,7 +287,8 @@ async def _test_llm_one(name: str, provider: LLMConfig) -> dict:
     payload = {
         "model": provider.model,
         "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
-        "temperature": 0,
+        # Kimi Code 端点（k3 思考模型）只接受 temperature=1
+        "temperature": 1 if _is_kimi_coding_endpoint(provider.base_url) else 0,
         "max_tokens": 8,
     }
     if protocol == "anthropic_messages":

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -64,6 +64,15 @@ def _api_root(base_url: str) -> str:
             return base[: -len(suffix)].rstrip("/")
     return base
 
+
+def _is_kimi_coding_endpoint(base_url: str) -> bool:
+    """Kimi Code 专用端点（https://api.kimi.com/coding/v1，k3 等思考模型）。
+
+    该端点只接受 temperature=1，传其它值会 HTTP 400
+    "invalid temperature: only 1 is allowed for this model"。
+    """
+    return "api.kimi.com/coding" in str(base_url or "").lower()
+
 # 浏览器 UA（伪装成 Chrome，绕过 Cloudflare/WAF 对 SDK UA 的封禁）
 _BROWSER_UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -1192,6 +1201,8 @@ class LLMClient:
             "temperature": self.config.temperature if temperature is None else temperature,
             "max_tokens": int(max_tokens or os.environ.get("LLM_MAX_TOKENS", "4096")),
         }
+        if _is_kimi_coding_endpoint(self.config.base_url):
+            kwargs["temperature"] = 1  # 该端点只接受 temperature=1
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice


### PR DESCRIPTION
修复 Kimi Code 官方端点强制 temperature=1
<img width="948" height="170" alt="QQ_1785408540827" src="https://github.com/user-attachments/assets/c078017a-983f-438a-8f06-cb214e6ee96f" />
