### PR TITLE
fix: 黑洞 DNS 解析防护与 worker 并发位超时保护

### DIFF
--- a/app/agents/prefilter.py
+++ b/app/agents/prefilter.py
@@ -11,11 +11,51 @@
 """
 from __future__ import annotations
 
+import contextlib
 import ipaddress
 import os
+import socket
+import threading
 from urllib.parse import urlparse
 
 import httpx
+
+# ---------------------------------------------------------------------------
+# 黑洞 DNS 防护：autodiscover 等记录常解析出几十个 IP（大量 IPv6 黑洞地址），
+# socket.create_connection 会逐个地址试到超时，单次探活可卡几分钟，进而把
+# 派发循环整批卡死。这里在探活期间把解析限制为 IPv4 前 2 个地址
+# （引用计数式临时替换，多线程安全；IPv6-only 域名自动回退原始解析）。
+# ---------------------------------------------------------------------------
+_ORIG_GETADDRINFO = socket.getaddrinfo
+_GA_LOCK = threading.Lock()
+_GA_DEPTH = 0
+
+
+def _capped_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    try:
+        res = _ORIG_GETADDRINFO(host, port, socket.AF_INET, type, proto, flags)
+    except OSError:
+        # 纯 IPv6 / 无 A 记录：回退原始解析，避免误杀 IPv6-only 站点
+        res = _ORIG_GETADDRINFO(host, port, family, type, proto, flags)
+    return res[:2]
+
+
+@contextlib.contextmanager
+def capped_resolution():
+    """探活期间限制 DNS 解析：IPv4 优先、最多 2 个地址。"""
+    global _GA_DEPTH
+    with _GA_LOCK:
+        if _GA_DEPTH == 0:
+            socket.getaddrinfo = _capped_getaddrinfo
+        _GA_DEPTH += 1
+    try:
+        yield
+    finally:
+        with _GA_LOCK:
+            _GA_DEPTH -= 1
+            if _GA_DEPTH == 0:
+                socket.getaddrinfo = _ORIG_GETADDRINFO
+
 
 # CDN / 对象存储 / 静态托管 域名特征（命中即跳过）
 _CDN_MARKERS = (
@@ -131,26 +171,27 @@ def is_cdn_host(host: str) -> bool:
 def probe(url: str, timeout: float = 8.0) -> dict:
     """探活：返回 {alive, status, server, body_len, is_spa}。失败则 alive=False。"""
     try:
-        with httpx.Client(timeout=timeout, verify=False, follow_redirects=True) as c:
-            r = c.get(url, headers={"User-Agent": "Mozilla/5.0 (compatible; AutoHunter)"})
-            body = r.text or ""
-            server = r.headers.get("server", "").lower()
-            # 粗判 SPA/纯前端：body 很短 + 含 <div id=app/root> + 几乎无表单/接口痕迹
-            low = body.lower()
-            is_spa = (
-                len(body) < 3000
-                and ('id="app"' in low or 'id="root"' in low or "<script" in low)
-                and "<form" not in low
-                and "login" not in low
-            )
-            import re
-            m = re.search(r"<title[^>]*>(.*?)</title>", body, re.I | re.S)
-            title = (m.group(1).strip()[:200] if m else "")
-            return {
-                "alive": True, "status": r.status_code, "server": server,
-                "body_len": len(body), "is_spa": is_spa,
-                "title": title, "body_snippet": body[:4000],
-            }
+        with capped_resolution():
+            with httpx.Client(timeout=timeout, verify=False, follow_redirects=True) as c:
+                r = c.get(url, headers={"User-Agent": "Mozilla/5.0 (compatible; AutoHunter)"})
+                body = r.text or ""
+                server = r.headers.get("server", "").lower()
+                # 粗判 SPA/纯前端：body 很短 + 含 <div id=app/root> + 几乎无表单/接口痕迹
+                low = body.lower()
+                is_spa = (
+                    len(body) < 3000
+                    and ('id="app"' in low or 'id="root"' in low or "<script" in low)
+                    and "<form" not in low
+                    and "login" not in low
+                )
+                import re
+                m = re.search(r"<title[^>]*>(.*?)</title>", body, re.I | re.S)
+                title = (m.group(1).strip()[:200] if m else "")
+                return {
+                    "alive": True, "status": r.status_code, "server": server,
+                    "body_len": len(body), "is_spa": is_spa,
+                    "title": title, "body_snippet": body[:4000],
+                }
     except Exception:
         return {"alive": False, "status": 0, "server": "", "body_len": 0,
                 "is_spa": False, "title": "", "body_snippet": ""}
@@ -162,7 +203,7 @@ def should_skip(host: str, url: str) -> tuple[bool, str]:
     return skip, reason
 
 
-def should_skip_ex(host: str, url: str) -> tuple[bool, str, dict]:
+def should_skip_ex(host: str, url: str, timeout: float = 8.0) -> tuple[bool, str, dict]:
     """同 should_skip，但额外返回首页探测信息(供评分复用，避免重复发包)。"""
     # 畸形主机（截断/非法 IPv6 等，拼进 URL 会崩解析）：直接跳过，不探活、不派 worker
     from app.urlnorm import is_unusable_host
@@ -173,7 +214,7 @@ def should_skip_ex(host: str, url: str) -> tuple[bool, str, dict]:
         return True, _SENSITIVE_SKIP_REASON, {}
     if is_cdn_host(host):
         return True, "CDN/对象存储/静态托管域名", {}
-    info = probe(url)
+    info = probe(url, timeout=timeout)
     if not info["alive"]:
         return True, "死链/连接超时/无响应", info
     # 5xx 暂时挂了，跳过本轮（不彻底淘汰，可后续重试）

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -112,6 +112,9 @@ WORKER_WALL_TIMEOUT = float(os.environ.get("WORKER_WALL_TIMEOUT", "1800"))
 WORKER_IDLE_TIMEOUT = float(os.environ.get("WORKER_IDLE_TIMEOUT", str(WORKER_WALL_TIMEOUT)))
 WORKER_MAX_WALL_TIMEOUT = float(os.environ.get("WORKER_MAX_WALL_TIMEOUT", str(max(WORKER_WALL_TIMEOUT * 4, WORKER_WALL_TIMEOUT))))
 WORKER_WAIT_POLL_INTERVAL = float(os.environ.get("WORKER_WAIT_POLL_INTERVAL", "10"))
+# 等待 worker 并发位的超时：并发位被幽灵线程长期占住时 acquire 可能永远等不到，
+# 超时后把目标回队列并退出本协程，避免「启动中…」无限挂起（由下一轮 tick 再试）。
+WORKER_SEM_ACQUIRE_TIMEOUT = float(os.environ.get("WORKER_SEM_ACQUIRE_TIMEOUT", "120"))
 REVIEW_WALL_TIMEOUT = float(os.environ.get("REVIEW_WALL_TIMEOUT", "600"))
 KILLSWEEP_WALL_TIMEOUT = float(os.environ.get("KILLSWEEP_WALL_TIMEOUT", "3600"))
 # 扩大危害深挖刻意克制：轮数少、墙钟短，打不动就撤。
@@ -303,7 +306,7 @@ def _probe_target_liveness(url: str, host: str, timeout: float) -> dict:
     urls = _probe_urls(url, host)
     skipped: list[dict] = []
     for probe_url in urls:
-        skip, reason, info = prefilter.should_skip_ex(host, probe_url)
+        skip, reason, info = prefilter.should_skip_ex(host, probe_url, timeout=timeout)
         if not skip:
             return {
                 "alive": True,
@@ -1996,7 +1999,27 @@ class TaskRunner:
         # 仍在跑的情况)时才释放，避免线程未退就放行新 worker 导致池子超订。
         worker_sem = agent_semaphore("worker")
         # acquire 本身可能被取消(pause/stop)——此时还没建 heartbeat/future，无需清理。
-        await worker_sem.acquire()
+        # 并发位超时保护：幽灵线程占位时 acquire 会无限等待，worker 会永久挂在
+        # 「启动中…」且没有心跳/超时兜底（历史现象：配了并发却只有 1 个在跑）。
+        # 等不到位就把目标回队列、退出本协程，由下一轮 tick 重新派发。
+        try:
+            await asyncio.wait_for(worker_sem.acquire(), timeout=WORKER_SEM_ACQUIRE_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[sem_wait] target=%s 等待 worker 并发位超时(%.0fs)，目标回队待重派，活跃协程=%d",
+                target_id[:8], WORKER_SEM_ACQUIRE_TIMEOUT, len(self._active_workers),
+            )
+            self._live.pop(target_id, None)
+            self._worker_last_activity.pop(target_id, None)
+            async with SessionLocal() as s2:
+                tgt = await s2.get(Target, target_id)
+                if tgt is not None and tgt.status == "scanning":
+                    tgt.status = "queued"
+                    tgt.assigned_worker = ""
+                    tgt.heartbeat_at = None
+                    tgt.last_error = f"等待 worker 并发位超时({WORKER_SEM_ACQUIRE_TIMEOUT:.0f}s)，已回队"
+                    await s2.commit()
+            return
         # 心跳放在拿到并发位之后再起：确保它的生命周期与 worker_future 完全对齐，
         # 任何一条退出路径都能在下方 finally 里把它取消，杜绝心跳协程泄漏。
         heartbeat_task = asyncio.create_task(self._heartbeat_target(target_id))
@@ -2012,7 +2035,17 @@ class TaskRunner:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await heartbeat_task
             raise
-        worker_future.add_done_callback(lambda _f: worker_sem.release())
+        # 幂等释放：future 正常完成释放一次；若线程卡死（future 永不完成），由下方
+        # 超时/取消路径强制释放一次，未来线程真返回时不会重复释放导致超订。
+        _sem_released = False
+
+        def _release_sem(_f: object = None) -> None:
+            nonlocal _sem_released
+            if not _sem_released:
+                _sem_released = True
+                worker_sem.release()
+
+        worker_future.add_done_callback(_release_sem)
         try:
             # 活跃续命：worker 有持续事件就不因旧的 30min 墙钟被误杀；
             # 真正卡死则按 idle timeout 回收，活跃过久也有 max wall 兜底。
@@ -2054,6 +2087,9 @@ class TaskRunner:
                         result["resume_context"] = cleaned.get("resume_context") or {}
             except Exception:
                 worker_future.add_done_callback(_consume_task_exception)
+                # 线程仍卡死未返回：强制释放并发位，防止幽灵线程永久占位
+                # （线程真返回时 _release_sem 幂等，不会重复释放）。
+                _release_sem()
             async with SessionLocal() as s:
                 await self._log(s, "worker", "timeout",
                                 f"目标超时强制回收：{timeout_reason}，已触发工具子进程清理",
@@ -2066,6 +2102,7 @@ class TaskRunner:
             if worker:
                 worker.executor.cancel_running()
             worker_future.add_done_callback(_consume_task_exception)
+            _release_sem()
         except Exception as e:
             result = {"verdict": "error", "findings": [], "error": str(e)}
         finally:

--- a/app/tools/executor.py
+++ b/app/tools/executor.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 import httpx
 
+from app.agents.prefilter import capped_resolution
 from app.config import worker_config
 from app.tools.decoder import decode_transform as _decode_transform
 from app.tools.guard import CommandBlocked, check_command
@@ -372,7 +373,8 @@ class ToolExecutor:
                 method.upper(), url, headers=merged_headers, content=data, json=json_body,
                 timeout=timeout,
             )
-            resp = client.send(req, stream=True, follow_redirects=follow_redirects)
+            with capped_resolution():
+                resp = client.send(req, stream=True, follow_redirects=follow_redirects)
             body, truncated = self._read_limited_response(resp)
             # 吸收整条重定向链（resp.history 里每个中间 302 + 最终响应）的 Set-Cookie，
             # 而不是只读最终 resp.cookies；再兜底吸收 client.cookies jar 里的全部。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@
 # ============================================================================
 services:
   autohunter:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.cn
     image: autohunter:latest
     container_name: autohunter
     ports:


### PR DESCRIPTION
## 改动内容

### 1. 黑洞 DNS 解析防护（prefilter.py / executor.py）
- autodiscover 等记录常解析出大量 IPv6 黑洞地址，socket.create_connection 会逐个尝试到超时，单次探活可卡几分钟，导致派发循环整批卡死
- 探活期间通过引用计数式临时替换 socket.getaddrinfo，限制为 IPv4 前 2 个地址（多线程安全，IPv6-only 域名自动回退）
- HTTP 请求同样应用该防护

### 2. worker 并发位超时保护（orchestrator.py）
- 并发位被幽灵线程长期占住时 acquire 可能永远等不到，worker 永久挂在「启动中…」
- 增加 WORKER_SEM_ACQUIRE_TIMEOUT（默认 120s）超时，超时后目标回队重派
- 信号量释放改为幂等（幂等释放防止幽灵线程返回时重复释放导致超订）

### 3. docker-compose
- 构建改为使用 Dockerfile.cn

## 测试
- prefilter / orchestrator / executor 均通过 py_compile 编译验证