### PR TITLE
fix: 修复 Reviewer 写证明自动采纳时的事件参数冲突

### DIFF
--- a/app/agents/reviewer.py
+++ b/app/agents/reviewer.py
@@ -359,7 +359,7 @@ class Reviewer:
         elif _maybe_reject_weak_backdoor(finding, review):
             self._emit("review_auto_ignore_weak_backdoor", title=finding.title)
         elif _maybe_accept_write_proof(finding, review):
-            self._emit("review_auto_accept_write", title=finding.title, kind=classify_write_proof(finding))
+            self._emit("review_auto_accept_write", title=finding.title, write_kind=classify_write_proof(finding))
         elif _maybe_deepen_ignored(finding, review, self.src_type):
             self._emit("review_auto_deepen", title=finding.title, directive=review.deepen_directive)
 

--- a/tests/test_write_proof.py
+++ b/tests/test_write_proof.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest.mock import patch
 
-from app.agents.reviewer import _maybe_accept_write_proof, _maybe_deepen_ignored
+from app.agents.reviewer import Reviewer, _maybe_accept_write_proof, _maybe_deepen_ignored
 from app.agents.write_proof import (
     KIND_AUTHZ_DIFF,
     KIND_SENTINEL,
@@ -128,6 +129,34 @@ class WriteProofTest(unittest.TestCase):
         self.assertTrue(_maybe_accept_write_proof(finding, review))
         self.assertEqual(review.verdict.value, "accepted")
         self.assertFalse(_maybe_deepen_ignored(finding, review, "edusrc"))
+
+    def test_reviewer_emits_write_kind_when_promoting_sentinel(self):
+        finding = _finding(
+            title="未授权可增删改自己的测试工单",
+            target_url="https://example.edu.cn/api/ticket/delete",
+            description="自建哨兵 SRC_TEST_a1b2 后旁路查询可见，删除后查询已消失。",
+            poc="curl -X DELETE https://example.edu.cn/api/ticket/delete?id=88",
+            evidence={"notes": "SRC_TEST_a1b2 删除后查询不存在，前后对比已齐"},
+        )
+        events = []
+        reviewer = Reviewer(
+            llm=object(),
+            on_event=lambda kind, data: events.append((kind, data)),
+            enable_reproduce=False,
+        )
+
+        with patch.object(
+            reviewer,
+            "_llm_review",
+            return_value=_ignored_review(ignore_reasons=["未破坏真实数据"]),
+        ):
+            review = reviewer.review(finding)
+
+        self.assertEqual(review.verdict.value, "accepted")
+        auto_event = next(data for kind, data in events if kind == "review_auto_accept_write")
+        self.assertEqual(auto_event["write_kind"], KIND_SENTINEL)
+        self.assertNotIn("kind", auto_event)
+        self.assertIn("review_done", [kind for kind, _ in events])
 
     def test_reviewer_does_not_promote_zero_effect(self):
         finding = _finding(


### PR DESCRIPTION
## Summary
- 修复写证明自动改判为 accepted 时，事件载荷 `kind` 与 `Reviewer._emit()` 形参冲突导致的 `TypeError`
- 将证明分类字段改为 `write_kind`，避免覆盖事件总线顶层的事件类型
- 增加覆盖完整 `Reviewer.review()` 路径的回归测试，验证 accepted 结论及事件载荷

## Test plan
- [x] `python -m unittest tests.test_write_proof`（8 项通过）
- [ ] `python -m unittest discover -s tests`（执行 196 项；当前环境有 3 failures / 5 errors，涉及缺少 pytest、LLM 环境变量及既有 mock/fixture，与本次两个改动文件无关）

## Deployment
- 无需数据库迁移
- 容器部署需重建并重启镜像以加载后端源码变更